### PR TITLE
fix: abort debug not work

### DIFF
--- a/src/tools/debugadapter/dapsession.cpp
+++ b/src/tools/debugadapter/dapsession.cpp
@@ -388,7 +388,7 @@ void DapSession::registerHanlder()
         dap::TerminateResponse response;
         Log("<-- Server received terminate request from client\n")
         // send quit command to debugger
-        emit DapProxy::instance()->sigQuit();
+        DebugManager::instance()->terminate();
 
         Log("--> Server sent terminate response to client\n")
         return response;

--- a/src/tools/debugadapter/debugmanager.cpp
+++ b/src/tools/debugadapter/debugmanager.cpp
@@ -186,6 +186,12 @@ void DebugManager::quit()
     command(d->debugger->quit());
 }
 
+void DebugManager::terminate()
+{
+    d->process->terminate();
+    emit terminated();
+}
+
 void DebugManager::kill()
 {
     command(d->debugger->kill());

--- a/src/tools/debugadapter/debugmanager.h
+++ b/src/tools/debugadapter/debugmanager.h
@@ -33,6 +33,7 @@ public:
     void initDebugger(const QString &program, const QStringList &arguments);
 
     void quit();
+    void terminate();
     void kill();
     void execute();
     void launchLocal();


### PR DESCRIPTION
terminate request not processed, end gdb
process to abort debug.

Log: fix abort debug not work
Change-Id: I174d2f308421c8190755fe1ea16b2714d84a5df1