### PR TITLE
feat: remove unused depend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Deepin Packages Builder <packages@linuxdeepin.com>
 Build-Depends:
  debhelper (>=9),
- dh-systemd,
  cmake,
  qt5-qmake,
  qtbase5-dev,


### PR DESCRIPTION
dh-systemd is a temporary depend, remove it now.

Log: control changed
Change-Id: Ie2c6f636b110cb6cfec24f19afe39d8b8f12f1e0