### PR TITLE
fix: historylistwidget dosen`t close after clicked historyItem

### DIFF
--- a/src/plugins/codegeex/widgets/historylistwidget.cpp
+++ b/src/plugins/codegeex/widgets/historylistwidget.cpp
@@ -89,6 +89,7 @@ void HistoryListWidget::initUI()
         item->setVisible(false);
 
         itemsList.append(item);
+        connect(item, &SessionRecordItem::closeHistoryWidget, this, &HistoryListWidget::requestCloseHistoryWidget);
     }
 
     mainLayout->addStretch(1);

--- a/src/plugins/codegeex/widgets/sessionrecorditem.cpp
+++ b/src/plugins/codegeex/widgets/sessionrecorditem.cpp
@@ -40,6 +40,7 @@ void SessionRecordItem::onDeleteButtonClicked()
 void SessionRecordItem::onRecordClicked()
 {
     CodeGeeXManager::instance()->sendMessage(promotLabel->text());
+    Q_EMIT closeHistoryWidget();
 }
 
 void SessionRecordItem::initUI()

--- a/src/plugins/codegeex/widgets/sessionrecorditem.h
+++ b/src/plugins/codegeex/widgets/sessionrecorditem.h
@@ -23,6 +23,9 @@ public Q_SLOTS:
     void onDeleteButtonClicked();
     void onRecordClicked();
 
+Q_SIGNALS:
+    void closeHistoryWidget();
+
 private:
     void initUI();
     void initConnection();


### PR DESCRIPTION
historylistwidget dosen`t close after clicked historyItem