### PR TITLE
fix: The expand icon of project treeview don't show

### DIFF
--- a/src/plugins/cxx/cmake/project/mainframe/cmakeasynparse.cpp
+++ b/src/plugins/cxx/cmake/project/mainframe/cmakeasynparse.cpp
@@ -124,11 +124,14 @@ QStandardItem *CmakeAsynParse::parseProject(QStandardItem *rootItem, const dpfse
             if (!relativePath.isEmpty() && relativePath != ".") {
                 cmakeParentItem = createParentItem(rootItem, relativePath);
             }
-            auto cmakeFileItem = new QStandardItem();
-            cmakeFileItem->setIcon(CustomIcons::icon(cmakeFileInfo));
-            cmakeFileItem->setText(cmakeFileInfo.fileName());
-            cmakeFileItem->setToolTip(cmakeFileInfo.filePath());
-            cmakeParentItem->appendRow(cmakeFileItem);
+
+            QMetaObject::invokeMethod(this, [=](){
+                auto cmakeFileItem = new QStandardItem();
+                cmakeFileItem->setIcon(CustomIcons::icon(cmakeFileInfo));
+                cmakeFileItem->setText(cmakeFileInfo.fileName());
+                cmakeFileItem->setToolTip(cmakeFileInfo.filePath());
+                cmakeParentItem->appendRow(cmakeFileItem);
+            });
 
             // monitor cmake file change to refresh project tree.
             if (cmakeParentItem == rootItem) {


### PR DESCRIPTION
The expand icon of project treeview don't show.