### PR TITLE
fix: Secondary popups of openProject are not displayed

### DIFF
--- a/src/plugins/project/projectcore.cpp
+++ b/src/plugins/project/projectcore.cpp
@@ -49,7 +49,7 @@ bool ProjectCore::start()
     }
 
     QObject::connect(&dpf::Listener::instance(), &dpf::Listener::pluginsStarted,
-                     this, &ProjectCore::pluginsStartedMain);
+                     this, &ProjectCore::pluginsStartedMain, Qt::DirectConnection);
 
 
     using namespace std::placeholders;


### PR DESCRIPTION
Secondary popups of openProject are not displayed