### PR TITLE
feat: reset window Minimumsize

### DIFF
--- a/src/plugins/core/mainframe/windowkeeper.cpp
+++ b/src/plugins/core/mainframe/windowkeeper.cpp
@@ -241,6 +241,7 @@ void WindowKeeper::layoutWindow(DMainWindow *window)
     window->setWindowTitle("Deepin Union Code");
     window->setWindowIcon(QIcon::fromTheme("ide"));
     window->setMinimumSize(QSize(MW_MIN_WIDTH, MW_MIN_HEIGHT));
+    window->resize(QSize(MW_WIDTH, MW_HEIGHT));
     window->setAttribute(Qt::WA_DeleteOnClose);
 
     window->titlebar()->setIcon(QIcon::fromTheme("ide"));
@@ -295,7 +296,7 @@ WindowKeeper::WindowKeeper(QObject *parent)
 
         //CommandLine Model will not show main window
         if (CommandParser::instance().getModel() != CommandParser::CommandLine) {
-            d->window->show();
+            d->window->showMaximized();
             waitingForStarted(d->window);
         }
         int currentScreenIndex = qApp->desktop()->screenNumber(d->window);

--- a/src/plugins/recent/mainframe/recentdisplay.cpp
+++ b/src/plugins/recent/mainframe/recentdisplay.cpp
@@ -232,7 +232,7 @@ RecentDisplay::RecentDisplay(DWidget *parent)
     d->btnOpenFile = new DPushButton(tr("Open File"));
     d->btnOpenProject = new DPushButton(tr("Open Project"));
     d->btnNewFileOrPro = new DPushButton(tr("New File or Project"));
-    vLayoutNav->setContentsMargins(60, 200, 60, 200);
+    vLayoutNav->setContentsMargins(60, 0, 60, 0);
     vLayoutNav->setSpacing(20);
     vLayoutNav->setAlignment(Qt::AlignCenter);
     vLayoutNav->addWidget(recentLogo);

--- a/src/services/window/windowelement.h
+++ b/src/services/window/windowelement.h
@@ -14,8 +14,11 @@
 // MW = MainWindow
 namespace dpfservice {
 
+inline const int MW_WIDTH { 1280 };
+inline const int MW_HEIGHT { 860 };
+
 inline const int MW_MIN_WIDTH { 1280 };
-inline const int MW_MIN_HEIGHT { 860 };
+inline const int MW_MIN_HEIGHT { 600 };
 
 inline const QString MWNA_RECENT { QObject::tr("Recent") };
 inline const QString MWNA_EDIT { QObject::tr("Edit") };


### PR DESCRIPTION
1.Set the default state to full screen
2.Adjusting the layout of the recentWindow
3.Adjust the minimum height of the mainWindowAdjust the minimum height of the window