### PR TITLE
fix: Incomplete display of the plug-in window

### DIFF
--- a/src/plugins/core/mainframe/plugindialog.cpp
+++ b/src/plugins/core/mainframe/plugindialog.cpp
@@ -21,7 +21,7 @@ PluginDialog::PluginDialog(QWidget *parent)
     : DAbstractDialog(parent),
       view(new dpf::PluginView(this))
 {
-    resize(1000, 600);
+    resize(1050, 600);
 
     DTitlebar *titleBar = new DTitlebar();
     titleBar->setMenuVisible(false);


### PR DESCRIPTION
Incomplete display of the plug-in window