### PR TITLE
fix: [debugger] watchData widget can`t show when switching navigation

### DIFF
--- a/src/plugins/core/uicontroller/controller.cpp
+++ b/src/plugins/core/uicontroller/controller.cpp
@@ -89,6 +89,7 @@ class ControllerPrivate
     QMap<QString, QString> modePluginMap { { CM_EDIT, MWNA_EDIT }, { CM_RECENT, MWNA_RECENT }, { CM_DEBUG, MWNA_DEBUG } };
     QString mode { "" };   //mode: CM_EDIT/CM_DEBUG/CM_RECENT
     QMap<QString, QList<WidgetInfo>> modeInfo;
+    QString currentNavigation { "" };
 
     QMap<QString, AbstractModule *> modules;
 
@@ -365,6 +366,9 @@ void Controller::addNavigationItemToBottom(AbstractAction *action, quint8 priori
 void Controller::switchWidgetNavigation(const QString &navName)
 {
     d->navigationBar->setNavActionChecked(navName, true);
+    if(d->currentNavigation == navName)
+        return;
+    d->currentNavigation = navName;
 
     d->mainWindow->hideAllWidget();
     d->mainWindow->hideTopTollBar();
@@ -372,8 +376,7 @@ void Controller::switchWidgetNavigation(const QString &navName)
 
     if (d->modePluginMap.values().contains(navName))
         raiseMode(d->modePluginMap.key(navName));
-    else
-        d->navigationActions[navName]->trigger();
+    d->navigationActions[navName]->trigger();
 
     //send event
     uiController.switchToWidget(navName);

--- a/src/plugins/debugger/debuggerplugin.cpp
+++ b/src/plugins/debugger/debuggerplugin.cpp
@@ -40,7 +40,7 @@ bool DebuggerPlugin::start()
     if (!debuggerService) {
         qCritical() << "Failed, can't found debugger service";
         abort();
-    }    
+    }
 
     debugManager->initialize(windowService, debuggerService);
 
@@ -49,7 +49,12 @@ bool DebuggerPlugin::start()
         action->setIcon(QIcon::fromTheme("debug-navigation"));
         windowService->addNavigationItem(new AbstractAction(action), 5);
         windowService->registerWidgetToMode("debugMainWindow", new AbstractWidget(debugManager->getDebugMainPane()), CM_DEBUG, Position::Left, true, true);
-        windowService->registerWidgetToMode("debuggerWatcher", new AbstractWidget(debugManager->getLocalsPane()), CM_DEBUG, Position::Right, true, false);
+        windowService->registerWidget("debuggerWatcher", new AbstractWidget(debugManager->getLocalsPane()));
+        connect(action, &QAction::triggered, this, [=]() {
+            windowService->showWidgetAtPosition("debuggerWatcher", Position::Right, true);
+            if (debugManager->getRunState() == AbstractDebugger::kNoRun)
+                debugManager->getLocalsPane()->hide();
+        }, Qt::DirectConnection);
     }
 
     connect(debugManager, &DebugManager::debugStarted, this, &DebuggerPlugin::slotDebugStarted);

--- a/src/plugins/debugger/debugmanager.cpp
+++ b/src/plugins/debugger/debugmanager.cpp
@@ -66,6 +66,11 @@ DWidget *DebugManager::getDebugMainPane() const
     return currentDebugger->getDebugMainPane();
 }
 
+AbstractDebugger::RunState DebugManager::getRunState() const
+{
+    return currentDebugger->getRunState();
+}
+
 void DebugManager::registerDebugger(const QString &kit, AbstractDebugger *debugger)
 {
     auto iterator = debuggers.find(kit);

--- a/src/plugins/debugger/debugmanager.h
+++ b/src/plugins/debugger/debugmanager.h
@@ -38,6 +38,7 @@ public:
     DWidget *getLocalsPane() const;
     DWidget *getBreakpointPane() const;
     DWidget *getDebugMainPane() const;
+    AbstractDebugger::RunState getRunState() const;
     void registerDebugger(const QString &kit, AbstractDebugger *debugger);
 
 signals:


### PR DESCRIPTION
watchData widget can`t show when switching navigation