### PR TITLE
fix: [project] crash when right-click the space area of project tree …

### DIFF
--- a/src/plugins/core/gui/workspacewidget.cpp
+++ b/src/plugins/core/gui/workspacewidget.cpp
@@ -54,7 +54,7 @@ void WorkspaceWidget::addWorkspaceWidget(const QString &title, AbstractWidget *t
 
     DToolButton *tabBtn = new DToolButton;
     tabBtn->setCheckable(true);
-    tabBtn->setChecked(true);
+    tabBtn->setChecked(false);
     tabBtn->setToolTip(title);
     tabBtn->setIcon(QIcon::fromTheme(iconName));
     tabBtn->setMinimumSize(QSize(24, 24));
@@ -68,6 +68,7 @@ void WorkspaceWidget::addWorkspaceWidget(const QString &title, AbstractWidget *t
         switchWidgetWorkspace(title);
     });
     workspaceTabButtons.insert(title, tabBtn);
+    switchWidgetWorkspace(title);
 }
 
 bool WorkspaceWidget::switchWidgetWorkspace(const QString &title)

--- a/src/plugins/project/mainframe/projecttree.cpp
+++ b/src/plugins/project/mainframe/projecttree.cpp
@@ -187,6 +187,9 @@ void ProjectTree::takeRootItem(QStandardItem *root)
 
 void ProjectTree::doItemMenuRequest(QStandardItem *item, QContextMenuEvent *event)
 {
+    if(!item)
+        return;
+
     auto rootItem = ProjectGenerator::root(item);
     DMenu *menu = nullptr;
 


### PR DESCRIPTION
…view

crash when right-click the space area of project tree view