### PR TITLE
fix: [debugger] can`t show variables When debugging projects outside …

### DIFF
--- a/src/plugins/debugger/dap/dapdebugger.cpp
+++ b/src/plugins/debugger/dap/dapdebugger.cpp
@@ -654,7 +654,7 @@ void DAPDebugger::handleFrames(const StackFrames &stackFrames)
 
     // update local variables.
     d->processingVariablesTimer.start(50);     // if processing time < 50ms, do not show spinner
-    d->getLocalsFuture = QtConcurrent::run([&](){
+    d->getLocalsFuture = QtConcurrent::run([=](){
         IVariables locals;
         getLocals(curFrame.frameId, &locals);
         d->localsModel.setDatas(locals);
@@ -775,9 +775,13 @@ void DAPDebugger::slotFrameSelected(const QModelIndex &index)
     }
 
     // update local variables.
-    IVariables locals;
-    getLocals(curFrame.frameId, &locals);
-    d->localsModel.setDatas(locals);
+    d->processingVariablesTimer.start(50);
+    QtConcurrent::run([=](){
+        IVariables locals;
+        getLocals(curFrame.frameId, &locals);
+        d->localsModel.setDatas(locals);
+        emit processingVariablesDone();
+    });
 }
 
 void DAPDebugger::slotBreakpointSelected(const QModelIndex &index)

--- a/src/plugins/debugger/dap/debugsession.cpp
+++ b/src/plugins/debugger/dap/debugsession.cpp
@@ -809,7 +809,7 @@ bool DebugSession::getLocals(dap::integer frameId, IVariables *out)
     for (auto scope : scopeRes.scopes) {
         if (scope.presentationHint.value("") == kLocals
                 || scope.name == "Local") {
-            return getVariables(0, out);
+            return getVariables(frameId, out);
         }
     }
 

--- a/src/tools/debugadapter/backendglobal.h
+++ b/src/tools/debugadapter/backendglobal.h
@@ -8,4 +8,8 @@
 //! May change output channal later.
 #define Log(message) printf("%s", message);
 
+static const int rootVariablesReference = 0;
+static const int registersReference = 1;
+static const int childVariablesReferenceBegin = 2;
+
 #endif // BACKENDGLOBAL_H

--- a/src/tools/debugadapter/dapsession.cpp
+++ b/src/tools/debugadapter/dapsession.cpp
@@ -513,12 +513,13 @@ void DapSession::registerHanlder()
         Log("<-- Server received Scopes request from the client\n")
         //emit DapProxy::instance()->sigScopes(frameId);
 
+        d->debugger->frameSelect(frameId);
         // locals
         dap::Scope scopeLocals;
         scopeLocals.presentationHint = "locals";
         scopeLocals.name = "Locals";
         scopeLocals.expensive = false;
-        scopeLocals.variablesReference = frameId;
+        scopeLocals.variablesReference = rootVariablesReference;
         scopes.push_back(scopeLocals);
 
         // register
@@ -526,7 +527,7 @@ void DapSession::registerHanlder()
         scopeRegisters.presentationHint = "registers";
         scopeRegisters.name = "Registers";
         scopeRegisters.expensive = false;
-        scopeRegisters.variablesReference = frameId + 1;
+        scopeRegisters.variablesReference = registersReference;
         scopes.push_back(scopeRegisters);
         response.scopes = scopes;
         Log("--> Server sent Scopes response to the client\n")

--- a/src/tools/debugadapter/debugger/debugger.h
+++ b/src/tools/debugadapter/debugger/debugger.h
@@ -34,6 +34,7 @@ public:
 
     virtual QString threadInfo() = 0;
     virtual QString threadSelect(const int threadId) = 0;
+    virtual QString frameSelect(const int threadId) = 0;
 
     virtual QString stackListFrames() = 0;
     virtual QString stackListVariables() = 0;

--- a/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.h
+++ b/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.h
@@ -44,6 +44,7 @@ public:
 
     QString threadInfo() override;
     QString threadSelect(const int threadId) override;
+    QString frameSelect(const int frameId) override;
 
     QString listSourceFiles() override;
 

--- a/src/tools/debugadapter/debugger/javascript/jsdebugger.cpp
+++ b/src/tools/debugadapter/debugger/javascript/jsdebugger.cpp
@@ -121,6 +121,12 @@ QString JSDebugger::threadSelect(const int threadId)
     RET_EMPTY
 }
 
+QString JSDebugger::frameSelect(const int frameId)
+{
+    Q_UNUSED(frameId);
+    RET_EMPTY
+}
+
 QString JSDebugger::listSourceFiles()
 {
     return ".list";

--- a/src/tools/debugadapter/debugger/javascript/jsdebugger.h
+++ b/src/tools/debugadapter/debugger/javascript/jsdebugger.h
@@ -41,6 +41,7 @@ public:
 
     QString threadInfo() override;
     QString threadSelect(const int threadId) override;
+    QString frameSelect(const int threadId) override;
 
     QString listSourceFiles() override;
 

--- a/src/tools/debugadapter/debugmanager.cpp
+++ b/src/tools/debugadapter/debugmanager.cpp
@@ -302,6 +302,11 @@ void DebugManager::listSourceFiles()
     command(d->debugger->listSourceFiles());
 }
 
+void DebugManager::frameSelect(const int frameId)
+{
+    command(d->debugger->frameSelect(frameId));
+}
+
 dap::array<dap::StackFrame> DebugManager::allStackframes()
 {
     return d->debugger->allStackframes();

--- a/src/tools/debugadapter/debugmanager.h
+++ b/src/tools/debugadapter/debugmanager.h
@@ -6,6 +6,7 @@
 #define DEBUGMANAGER_H
 
 #include "debugger/gdbmi/gdbdebugger.h"
+#include "backendglobal.h"
 
 #include "dap/protocol.h"
 
@@ -53,6 +54,7 @@ public:
 
     void threadInfo();
     void threadSelect(const int threadId);
+    void frameSelect(const int frameId);
 
     void stackListFrames();
     void stackListVariables();


### PR DESCRIPTION
…of C++

1.can`t show variables When debugging projects outside of C++ 2.didn`t free variableslock when getVariables = 0