### PR TITLE
fix: [debugger] can`t operating when project is running

### DIFF
--- a/src/plugins/debugger/dap/debugsession.cpp
+++ b/src/plugins/debugger/dap/debugsession.cpp
@@ -809,7 +809,7 @@ bool DebugSession::getLocals(dap::integer frameId, IVariables *out)
     for (auto scope : scopeRes.scopes) {
         if (scope.presentationHint.value("") == kLocals
                 || scope.name == "Local") {
-            return getVariables(frameId, out);
+            return getVariables(scope.variablesReference, out);
         }
     }
 

--- a/src/tools/debugadapter/dapproxy.h
+++ b/src/tools/debugadapter/dapproxy.h
@@ -40,8 +40,9 @@ Q_SIGNALS:
     void sigScopes(const qint64 frame);
     void sigVariables();
     void sigSource();
-    void sigStreamOutput(const QString sOut);
+    void sigStreamOutput(const QString &sOut);
     void sigBreakRemoveAll();
+    void sigUpdateBreakpoints(const QString &file, const QList<int> &lines);
 
 private:
     explicit DapProxy(QObject *parent = nullptr);

--- a/src/tools/debugadapter/dapsession.cpp
+++ b/src/tools/debugadapter/dapsession.cpp
@@ -172,6 +172,11 @@ void DapSession::initializeDebugMgr()
         handleOutputTextEvent(textList);
     });
 
+    connect(d->debugger, &DebugManager::asyncContinued, DapProxy::instance(), [this](const dap::ContinuedEvent &continuedEvent) mutable {
+        handleAsyncContinued(continuedEvent);
+        d->isInferiorStopped = false;
+    });
+
     connect(d->debugger, &DebugManager::asyncStopped, DapProxy::instance(), [this](const dap::StoppedEvent &stoppedEvent) mutable {
         handleAsyncStopped(stoppedEvent);
         d->isInferiorStopped = true;
@@ -218,9 +223,10 @@ void DapSession::initializeDebugMgr()
     connect(DapProxy::instance(), &DapProxy::sigKill, d->debugger, &DebugManager::kill, SequentialExecution);
     connect(DapProxy::instance(), &DapProxy::sigStart, d->debugger, &DebugManager::execute, SequentialExecution);
     connect(DapProxy::instance(), &DapProxy::sigBreakInsert, d->debugger, &DebugManager::breakInsert, SequentialExecution);
+    connect(DapProxy::instance(), &DapProxy::sigUpdateBreakpoints, d->debugger, &DebugManager::updateBreakpoints, SequentialExecution);
     connect(DapProxy::instance(), &DapProxy::sigLaunchLocal, d->debugger, &DebugManager::launchLocal, SequentialExecution);
     connect(DapProxy::instance(), &DapProxy::sigContinue, d->debugger, &DebugManager::commandContinue, SequentialExecution);
-    connect(DapProxy::instance(), &DapProxy::sigPause, d->debugger, &DebugManager::commandPause, SequentialExecution);
+    connect(DapProxy::instance(), &DapProxy::sigPause, d->debugger, &DebugManager::pauseDebugger, SequentialExecution);
     connect(DapProxy::instance(), &DapProxy::sigNext, d->debugger, &DebugManager::commandNext, SequentialExecution);
     connect(DapProxy::instance(), &DapProxy::sigStepin, d->debugger, &DebugManager::commandStep, SequentialExecution);
     connect(DapProxy::instance(), &DapProxy::sigStepout, d->debugger, &DebugManager::commandFinish, SequentialExecution);
@@ -520,6 +526,7 @@ void DapSession::registerHanlder()
         scopeLocals.name = "Locals";
         scopeLocals.expensive = false;
         scopeLocals.variablesReference = rootVariablesReference;
+        scopeLocals.variablesReference = 0;
         scopes.push_back(scopeLocals);
 
         // register
@@ -528,6 +535,7 @@ void DapSession::registerHanlder()
         scopeRegisters.name = "Registers";
         scopeRegisters.expensive = false;
         scopeRegisters.variablesReference = registersReference;
+        scopeLocals.variablesReference = 1;
         scopes.push_back(scopeRegisters);
         response.scopes = scopes;
         Log("--> Server sent Scopes response to the client\n")
@@ -591,6 +599,12 @@ void DapSession::registerHanlder()
         Log("--> Server sent disassemble response to client\n")
         return dap::DisassembleResponse();
     });
+}
+
+void DapSession::handleAsyncContinued(const dap::ContinuedEvent &continuedEvent)
+{
+    d->session->send(continuedEvent);
+    Log("--> Server sent continued event to client\n")
 }
 
 void DapSession::handleAsyncStopped(const dap::StoppedEvent &stoppedEvent)
@@ -673,29 +687,28 @@ dap::SetBreakpointsResponse DapSession::handleBreakpointReq(const SetBreakpoints
     }
 
     const char *sourcePath = request.source.path->c_str();
-    d->debugger->removeBreakpointInFile(sourcePath);
     if (request.breakpoints.has_value()) {
         dap::array<dap::Breakpoint> breakpoints;
+        QList<int> lines;
         for (auto &breakpoint : request.breakpoints.value()) {
             dap::Breakpoint bp;
             dap::Source source;
-            QString location;
             if (request.source.path.has_value()) {
                 source = request.source;
             }
-            location = source.path.value().c_str();
-            location.append(":");
-            location.append(QString::number(breakpoint.line));
-            emit DapProxy::instance()->sigBreakInsert(location);
 
             bp.line = breakpoint.line;
             bp.source = request.source;
+            lines.append(breakpoint.line);
             breakpoints.push_back(bp);
         }
 
+        emit DapProxy::instance()->sigUpdateBreakpoints(sourcePath, lines);
         // Generic response
         Log("--> Server sent  setBreakpoints response to client\n")
         response.breakpoints = breakpoints;
+    } else {
+        d->debugger->removeBreakpointInFile(sourcePath);
     }
 
     // return empty response to client, when lines and breakpoints all empty.

--- a/src/tools/debugadapter/dapsession.h
+++ b/src/tools/debugadapter/dapsession.h
@@ -38,6 +38,7 @@ private:
 
     void handleOutputTextEvent(const QStringList &textList);
     void handleStreamConsole(const QString &text);
+    void handleAsyncContinued(const dap::ContinuedEvent &continuedEvent);
     void handleAsyncStopped(const dap::StoppedEvent &stoppedevent);
     void handleAsyncExited(const dap::ExitedEvent &exitedEvent);
     void handleLibraryLoaded(const dap::ModuleEvent &moduleEvent);

--- a/src/tools/debugadapter/debugger/debugger.h
+++ b/src/tools/debugadapter/debugger/debugger.h
@@ -22,11 +22,12 @@ public:
     virtual QString kill() = 0;
     virtual QString launchLocal() = 0;
 
+    virtual void updateBreakpoints(const QString &file, const QList<int> &lines) = 0;
     virtual QString breakRemoveAll() = 0;
     virtual QString breakInsert(const QString& path) = 0;
     virtual QString breakRemove(int bpid) = 0;
 
-    virtual QString commandPause() = 0;
+    virtual void pause() = 0;
     virtual QString commandContinue() = 0;
     virtual QString commandNext() = 0;
     virtual QString commandStep() = 0;

--- a/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.cpp
+++ b/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.cpp
@@ -43,6 +43,7 @@ GDBDebugger::GDBDebugger(QObject *parent)
 {
     connect(this, &GDBDebugger::streamConsole, DebugManager::instance(), &DebugManager::streamConsole);
     connect(this, &GDBDebugger::streamDebugInternal, DebugManager::instance(), &DebugManager::streamDebugInternal);
+    connect(this, &GDBDebugger::asyncContinued, DebugManager::instance(), &DebugManager::asyncContinued);
     connect(this, &GDBDebugger::asyncStopped, DebugManager::instance(), &DebugManager::asyncStopped);
     connect(this, &GDBDebugger::asyncExited, DebugManager::instance(), &DebugManager::asyncExited);
     connect(this, &GDBDebugger::asyncRunning, DebugManager::instance(), &DebugManager::asyncRunning);
@@ -64,8 +65,8 @@ GDBDebugger::~GDBDebugger()
 void GDBDebugger::init()
 {
     //use to debugging adapter
-//    DebugManager::instance()->command("set logging file /tmp/log.txt");
-//    DebugManager::instance()->command("set logging on");
+    DebugManager::instance()->command("set logging file /tmp/log.txt");
+    DebugManager::instance()->command("set logging on");
 
     QString prettyPrintersPath = CustomPaths::CustomPaths::global(CustomPaths::Scripts) + "/prettyprinters";
     DebugManager::instance()->command(QString("python sys.path.insert(0, \"%1\")").arg(prettyPrintersPath));
@@ -136,9 +137,10 @@ QString GDBDebugger::stackListVariables()
     return ("-stack-list-variables 1"); //0 or \"--no-values\", 1 or \"--all-values\", 2 or \"--simple-values\"
 }
 
-QString GDBDebugger::commandPause()
+void GDBDebugger::pause()
 {
-    return ("-exec-until");
+    d->inferiorRunning.store(false);
+    return;
 }
 
 QString GDBDebugger::commandContinue()
@@ -181,6 +183,35 @@ QString GDBDebugger::listSourceFiles()
     return ("-file-list-exec-source-files");
 }
 
+void GDBDebugger::updateBreakpoints(const QString &file, const QList<int> &lines)
+{
+    QList<int> curLines;
+    //remove canceled bp
+    for (auto it = d->breakpoints.cbegin(); it != d->breakpoints.cend(); ++it) {
+        auto& bp = it.value();
+        if (bp.fullname == file || bp.originalLocation.split(":").first() == file) {
+            //true line in editor
+            QString originalLine = bp.originalLocation.split(":").last();
+            bool ok = false;
+            int line = originalLine.toInt(&ok);
+            if (ok && !lines.contains(line))
+                DebugManager::instance()->breakRemove(bp.number);
+            else
+                curLines.append(line);
+        }
+    }
+
+    //append new bp
+    for (auto line : lines) {
+        if (!curLines.contains(line)) {
+            auto filePath = file;
+            filePath.append(":");
+            filePath.append(QString::number(line));
+            DebugManager::instance()->breakInsert(filePath);
+        }
+    }
+}
+
 void GDBDebugger::parseBreakPoint(const QVariant& var)
 {
     auto data = var.toMap();
@@ -206,7 +237,8 @@ QList<int> GDBDebugger::breakpointsForFile(const QString &filePath)
     QList<int> list;
     for (auto it = d->breakpoints.cbegin(); it != d->breakpoints.cend(); ++it) {
         auto& bp = it.value();
-        if (bp.fullname == filePath)
+        if (bp.fullname == filePath
+            || bp.originalLocation.split(":").first() == filePath)
             list.append(bp.number);
     }
     return list;
@@ -367,6 +399,9 @@ void GDBDebugger::parseNotifyData(gdbmi::Record &record)
         auto data = record.payload.toMap();
         auto thid = data.value("thread-id").toString();
         d->inferiorRunning.store(true);
+
+        dap::ContinuedEvent event;
+        emit asyncContinued(event);
         emit asyncRunning("gdb", thid);
     } else if (record.message == "breakpoint-modified") {
         // =breakpoint-modified,bkpt={...}
@@ -546,8 +581,8 @@ void GDBDebugger::parseResultData(gdbmi::Record &record)
                 d->breakpoints.insert(bp.number, bp);
                 emit breakpointInserted(bp);
             }
-            emit updateExceptResponse(record.token, record.payload);
         }
+        emit updateExceptResponse(record.token, record.payload);
     } else if (record.message == "connected") {
         emit targetRemoteConnected();
     } else if (record.message == "error") {

--- a/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.h
+++ b/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.h
@@ -33,7 +33,7 @@ public:
 
     QString launchLocal() override;
 
-    QString commandPause() override;
+    void pause() override;
     QString commandContinue() override;
     QString commandNext() override;
     QString commandStep() override;
@@ -61,6 +61,7 @@ public:
     void handleOutputRecord(const QString &text) override;
     void handleOutputStreamText(const QString &streamText) override;
 
+    void updateBreakpoints(const QString &file, const QList<int> &lines) override;
     void parseBreakPoint(const QVariant& var) override;
     void removeBreakPoint(const int bpid) override;
     void clearBreakPoint() override;
@@ -74,6 +75,7 @@ signals:
     void streamDebugInternal(const QStringList& textList);
     void streamConsole(const QString& text);
     void asyncStopped(const dap::StoppedEvent &stoppedEvent);
+    void asyncContinued(const dap::ContinuedEvent &continuedEvent);
     void asyncExited(const dap::ExitedEvent &exitedEvent);
     void asyncRunning(const QString& processName, const QString& theadId);
     void libraryLoaded(const dap::ModuleEvent &moduleEvent);

--- a/src/tools/debugadapter/debugger/javascript/jsdebugger.cpp
+++ b/src/tools/debugadapter/debugger/javascript/jsdebugger.cpp
@@ -55,6 +55,17 @@ QString JSDebugger::kill()
     RET_EMPTY
 }
 
+void JSDebugger::updateBreakpoints(const QString &file, const QList<int> &lines)
+{
+    DebugManager::instance()->breakRemoveAll();
+    auto filePath = file;
+    for (auto line : lines) {
+        filePath.append(":");
+        filePath.append(QString::number(line));
+        DebugManager::instance()->breakInsert(filePath);
+    }
+}
+
 QString JSDebugger::breakInsert(const QString &path)
 {
     return ".break " + path;
@@ -75,9 +86,9 @@ QString JSDebugger::launchLocal()
     return "";
 }
 
-QString JSDebugger::commandPause()
+void JSDebugger::pause()
 {
-    RET_EMPTY
+    return;
 }
 
 QString JSDebugger::commandContinue()

--- a/src/tools/debugadapter/debugger/javascript/jsdebugger.h
+++ b/src/tools/debugadapter/debugger/javascript/jsdebugger.h
@@ -24,13 +24,14 @@ public:
     QString quit() override;
     QString kill() override;
 
+    void updateBreakpoints(const QString &file, const QList<int> &lines) override;
     QString breakInsert(const QString& path) override;
     QString breakRemove(int bpid) override;
     QString breakRemoveAll() override;
 
     QString launchLocal() override;
 
-    QString commandPause() override;
+    void pause() override;
     QString commandContinue() override;
     QString commandNext() override;
     QString commandStep() override;

--- a/src/tools/debugadapter/debugmanager.h
+++ b/src/tools/debugadapter/debugmanager.h
@@ -41,12 +41,13 @@ public:
 
     qint64 getProcessId();
 
+    void updateBreakpoints(const QString &file, const QList<int> &lines);
     void breakRemoveAll();
     void breakInsert(const QString& path);
     void removeBreakpointInFile(const QString &filePath);
     void breakRemove(int bpid);
 
-    void commandPause();
+    void pauseDebugger();
     void commandContinue();
     void commandNext();
     void commandStep();
@@ -71,6 +72,7 @@ public:
 signals:
     void streamConsole(const QString& text);
     void streamDebugInternal(const QStringList &textList);
+    void asyncContinued(const dap::ContinuedEvent &continuedEvent);
     void asyncStopped(const dap::StoppedEvent &stoppedEvent);
     void asyncExited(const dap::ExitedEvent &exitedEvent);
     void asyncRunning(const QString& processName, const QString& theadId);
@@ -94,9 +96,10 @@ private:
 
     void initProcess();
 
-    bool command(const QString &cmd);
+    bool command(const QString &cmd, bool interrupt = false);
     void commandAndResponse(const QString& cmd,
                             const ResponseEntry::ResponseHandler_t& handler,
+                            bool interrupt = false,
                             ResponseEntry::ResponseAction_t action = ResponseEntry::ResponseAction_t::Temporal);
     bool isExecuting() const;
     void waitLocker();


### PR DESCRIPTION
1.While GDB is running, the input command is invalid and needs to be paused before executing the command.” 2.Optimize operations related to breakpoints