### PR TITLE
fix: [project] The file was added to the wrong directory

### DIFF
--- a/src/plugins/cxx/cmake/project/cmakeasynparse.cpp
+++ b/src/plugins/cxx/cmake/project/cmakeasynparse.cpp
@@ -320,6 +320,7 @@ QStandardItem *CmakeAsynParse::findParentItem(QStandardItem *rootItem, QString &
 QStandardItem *CmakeAsynParse::createParentItem(QStandardItem *rootItem, const QString &relativeName, const QString &absolutePath)
 {
     QStandardItem *retItem = nullptr;
+    QString basePath = absolutePath.mid(0, absolutePath.length() - relativeName.length());
     QStringList nameItems = relativeName.split("/");
     QString preItems;
     for (auto nameItem : nameItems) {
@@ -329,7 +330,7 @@ QStandardItem *CmakeAsynParse::createParentItem(QStandardItem *rootItem, const Q
             // create new one.
             item = new QStandardItem();
             item->setText(nameItem);
-            item->setToolTip(absolutePath);
+            item->setToolTip(basePath + relative);
             item->setIcon(::cmakeFolderIcon());
             // append to parent.
             QStandardItem *parentItem = findParentItem(rootItem, relative);


### PR DESCRIPTION
When adding files in projectTreeView, the files are added to the wrong directory