### PR TITLE
fix: [mainWindow] empty context menu when right-clicked the navigationbar

### DIFF
--- a/src/plugins/core/gui/navigationbar.cpp
+++ b/src/plugins/core/gui/navigationbar.cpp
@@ -13,6 +13,7 @@ NavigationBar::NavigationBar(QWidget *parent)
 {
     setLineWidth(0);
     setFixedWidth(58);
+    setContextMenuPolicy(Qt::NoContextMenu);
 
     DStyle::setFrameRadius(this, 0);
 

--- a/src/plugins/core/uicontroller/mainwindow.cpp
+++ b/src/plugins/core/uicontroller/mainwindow.cpp
@@ -62,6 +62,7 @@ MainWindow::MainWindow(QWidget *parent)
     setAttribute(Qt::WA_DeleteOnClose);
 
     addTopToolBar();
+    setContextMenuPolicy(Qt::NoContextMenu);  //donot show left toolbar`s contextmenu
     //setStyleSheet("QMainWindow::separator { width: 2px; margin: 0px; padding: 0px; }");
 
     setCorner(Qt::Corner::BottomLeftCorner, Qt::DockWidgetArea::LeftDockWidgetArea);


### PR DESCRIPTION
do not show context menu when right-clicked the navigationbar