### PR TITLE
fix: [projectTree] remove "delete File" option when right-clicked a dir

### DIFF
--- a/src/plugins/project/mainframe/projecttree.cpp
+++ b/src/plugins/project/mainframe/projecttree.cpp
@@ -358,21 +358,20 @@ DMenu *ProjectTree::childMenu(const QStandardItem *root, QStandardItem *childIte
         actionOpenInTerminal(childItem);
     });
 
-    // add delete file menu item.
-    QAction *deleteDocAction = new QAction(tr("Delete Document"), this);
-    QObject::connect(deleteDocAction, &QAction::triggered, this, [=](){
-        actionDeleteDocument(childItem);
-    });
-
-    if (info.isDir()) {
+    if (info.isDir())
         menu->addAction(newDocAction);
-        deleteDocAction->setEnabled(false);
-    }
+
     if (info.isFile()) {
         newDocAction->setEnabled(false);
+        // add delete file menu item.
+        QAction *deleteDocAction = new QAction(tr("Delete Document"), this);
+        QObject::connect(deleteDocAction, &QAction::triggered, this, [=](){
+            actionDeleteDocument(childItem);
+        });
         deleteDocAction->setEnabled(true);
+
+        menu->addAction(deleteDocAction);
     }
-    menu->addAction(deleteDocAction);
 
     return menu;
 }


### PR DESCRIPTION
 remove "delete File" option when right-clicked a dir

Bug: https://pms.uniontech.com/bug-view-246243.html