### PR TITLE
fix: [binarytools] rename issue in binarytools dialog

### DIFF
--- a/src/plugins/binarytools/mainframe/binarytoolsconfigview.cpp
+++ b/src/plugins/binarytools/mainframe/binarytoolsconfigview.cpp
@@ -165,6 +165,8 @@ BinaryToolsConfigView::~BinaryToolsConfigView()
 {
     if (d)
         delete d;
+
+    hasRename = false;
 }
 
 bool BinaryToolsConfigView::saveConfig()
@@ -376,29 +378,19 @@ void BinaryToolsConfigView::renameCompatConfig()
         }else if(index == 1){
             QString name = searchLineEdit->text(); // 在按钮点击时获取文本框内容
 
-            if (name == d->runComandCombo->currentText())
+            QString oldname = d->runComandCombo->currentText();
+            if (name == oldname)
                 return;
 
             QString uniName = uniqueName(name);
             if (uniName.isEmpty())
                 return;
 
-            QStringList allCommand = qvariant_cast<QStringList>(d->settings->getValue(ALL_COMMAND));
-            int index = allCommand.indexOf(d->runComandCombo->currentText());
-            if (index != -1) {
-                allCommand.replace(index, uniName);
-            } else {
-                allCommand.append(uniName);
-            }
-            d->settings->setValue(CURRENT_COMMAND, uniName);
-            d->settings->setValue(ALL_COMMAND, allCommand);
-            d->nameLabel->setText(name);
-            QStringList commandList = QStringList() << d->executableDirEdit->text()<< d->toolArgsEdit->text()
-                                                    << d->nameLabel->text() << d->workingDirEdit->text();
-            d->settings->setValue(uniName, commandList);
-            d->settings->setValue(uniName + ENVIRONMENT, d->envView->getEnvironment());
-            d->settings->deleteKey(d->runComandCombo->currentText());
-            d->settings->deleteKey(d->runComandCombo->currentText() + ENVIRONMENT);
+            hasRename = true;
+            renameInfo.name = name;
+            renameInfo.oldName = oldname;
+            renameInfo.index = d->runComandCombo->currentIndex();
+            renameInfo.uniName = uniName;
 
             int itemIndex = d->runComandCombo->currentIndex();
             d->runComandCombo->insertItem(itemIndex + 1, uniName);
@@ -409,6 +401,39 @@ void BinaryToolsConfigView::renameCompatConfig()
     });
 
     d->renameDialog->exec();
+}
+
+void BinaryToolsConfigView::renameConfigOperation(const QString &name, const QString &oldname, const QString &uniName)
+{
+    if (oldname.isEmpty()){
+        return;
+    }
+    QStringList allCommand = qvariant_cast<QStringList>(d->settings->getValue(ALL_COMMAND));
+    int index = allCommand.indexOf(oldname);
+    if (index != -1) {
+        allCommand.replace(index, uniName);
+    } else {
+        allCommand.append(uniName);
+    }
+    d->settings->setValue(CURRENT_COMMAND, uniName);
+    d->settings->setValue(ALL_COMMAND, allCommand);
+    d->nameLabel->setText(name);
+    QStringList commandList = QStringList() << d->executableDirEdit->text()<< d->toolArgsEdit->text()
+                                            << d->nameLabel->text() << d->workingDirEdit->text();
+    d->settings->setValue(uniName, commandList);
+    d->settings->setValue(uniName + ENVIRONMENT, d->envView->getEnvironment());
+    d->settings->deleteKey(oldname);
+    d->settings->deleteKey(oldname + ENVIRONMENT);
+}
+
+void BinaryToolsConfigView::resetConfigOperation(const QString &oldname, int index)
+{
+    if (oldname.isEmpty()){
+        return;
+    }
+    d->runComandCombo->insertItem(index + 1, oldname);
+    d->runComandCombo->setCurrentText(oldname);
+    d->runComandCombo->removeItem(index);
 }
 
 void BinaryToolsConfigView::combineCompatConfig()

--- a/src/plugins/binarytools/mainframe/binarytoolsconfigview.h
+++ b/src/plugins/binarytools/mainframe/binarytoolsconfigview.h
@@ -12,11 +12,23 @@ class BinaryToolsConfigView : public DTK_WIDGET_NAMESPACE::DWidget
 {
     Q_OBJECT
 public:
+    struct RenameInfo{
+        QString oldName = "";
+        QString name = "";
+        int index = -1;
+        QString uniName = "";
+    };
+
     explicit BinaryToolsConfigView(QWidget *parent = nullptr);
     ~BinaryToolsConfigView();
 
     bool saveConfig();
     void readConfig();
+    void renameConfigOperation(const QString &name, const QString &oldname, const QString &uniName);
+    void resetConfigOperation(const QString &oldname, int index);
+
+    bool hasRename = false; // Whether the rename button was clicked
+    RenameInfo renameInfo;
 
     QList<QString> getProgramList();
     QList<QStringList> getArgumentsList();

--- a/src/plugins/binarytools/mainframe/binarytoolsdialog.cpp
+++ b/src/plugins/binarytools/mainframe/binarytoolsdialog.cpp
@@ -84,6 +84,7 @@ BinaryToolsDialog::BinaryToolsDialog(QDialog *parent)
 
      connect(saveButton, &DPushButton::clicked, this, &BinaryToolsDialog::accept);
      connect(cancelButton, &DPushButton::clicked, this, &BinaryToolsDialog::reject);
+     connect(cancelButton, &DPushButton::clicked, this, &BinaryToolsDialog::cancelClicked);
      connect(applyButton, &DSuggestButton::clicked, this, &BinaryToolsDialog::accept);
 }
 
@@ -117,12 +118,38 @@ void BinaryToolsDialog::printOutput(const QString &content, OutputPane::OutputFo
 
 void BinaryToolsDialog::saveClicked()
 {
+    doSaveOperation();
+}
+
+void BinaryToolsDialog::doSaveOperation(){
     d->configView->saveConfig();
+    if (canRename()) {
+        QString &name = d->configView->renameInfo.name;
+        QString &oldname = d->configView->renameInfo.oldName;
+        QString &uniName = d->configView->renameInfo.uniName;
+        d->configView->renameConfigOperation(name, oldname, uniName);
+    }
+}
+
+bool BinaryToolsDialog::canRename(){
+    return d->configView->hasRename && !d->configView->renameInfo.name.isEmpty() &&
+            !d->configView->renameInfo.oldName.isEmpty() &&
+            !d->configView->renameInfo.uniName.isEmpty();
+}
+
+void BinaryToolsDialog::cancelClicked()
+{
+    if (d->configView->hasRename && !d->configView->renameInfo.oldName.isEmpty() &&
+            (d->configView->renameInfo.index != -1)) {
+        QString &oldname = d->configView->renameInfo.oldName;
+        int index = d->configView->renameInfo.index;
+        d->configView->resetConfigOperation(oldname, index);
+    }
 }
 
 void BinaryToolsDialog::useClicked()
 {
-    d->configView->saveConfig();
+    doSaveOperation();
 
     QProcess proc;
     QString retMsg = tr("Error: execute command error! The reason is unknown.\n");;

--- a/src/plugins/binarytools/mainframe/binarytoolsdialog.h
+++ b/src/plugins/binarytools/mainframe/binarytoolsdialog.h
@@ -23,10 +23,13 @@ signals:
 public slots:
     void printOutput(const QString &content, OutputPane::OutputFormat format);
     void saveClicked();
+    void cancelClicked();
     void useClicked();
 
 private:
     void outputMsg(const QString &content, OutputPane::OutputFormat format);
+    bool canRename();
+    void doSaveOperation();
 
     BinaryToolsDialogPrivate *const d = nullptr;
 };


### PR DESCRIPTION
Fixed an issue in binary dialog where renaming occurred after clicking Cancel

Bug: https://pms.uniontech.com/bug-view-246913.html