### PR TITLE
fix: [optioncore] Fixed that shortcut keys could not be cancelled

### DIFF
--- a/src/plugins/option/optioncore/CMakeLists.txt
+++ b/src/plugins/option/optioncore/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CXX_CPP
     mainframe/optionprofilesettinggenerator.cpp
     mainframe/optionshortcutsettinggenerator.cpp
     mainframe/navigationdelegate.cpp
+    mainframe/shortcutedit.cpp
     optioncore.cpp
     optioncore.json
     )
@@ -30,6 +31,7 @@ set(CXX_H
     mainframe/optionprofilesettinggenerator.h
     mainframe/optionshortcutsettinggenerator.h
     mainframe/navigationdelegate.h
+    mainframe/shortcutedit.h
     optioncore.h
     )
 

--- a/src/plugins/option/optioncore/mainframe/shortcutedit.cpp
+++ b/src/plugins/option/optioncore/mainframe/shortcutedit.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "shortcutedit.h"
+
+ShortCutEdit::ShortCutEdit(QWidget *parent)
+    : DKeySequenceEdit(parent)
+{
+    menu = new DMenu(this);
+    QAction *clearAction = menu->addAction(tr("Clear"));
+    connect(clearAction, &QAction::triggered, this, &ShortCutEdit::clearText);
+}
+
+void ShortCutEdit::clearText() 
+{
+    this->clear();
+    emit shortcutCleared();
+}

--- a/src/plugins/option/optioncore/mainframe/shortcutedit.h
+++ b/src/plugins/option/optioncore/mainframe/shortcutedit.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <DKeySequenceEdit>
+#include <DMenu>
+
+#include <QAction>
+#include <QContextMenuEvent>
+
+using Dtk::Widget::DMenu;
+
+class ShortCutEdit : public Dtk::Widget::DKeySequenceEdit
+{
+    Q_OBJECT
+public:
+    ShortCutEdit(QWidget *parent = nullptr);
+
+protected:
+    void contextMenuEvent(QContextMenuEvent *event) override 
+    {
+        menu->exec(event->globalPos());
+    }
+
+signals:
+    void shortcutCleared();
+
+private slots:
+    void clearText();
+
+private:
+    DMenu *menu = nullptr;
+};
+

--- a/src/plugins/option/optioncore/mainframe/shortcutsettingwidget.cpp
+++ b/src/plugins/option/optioncore/mainframe/shortcutsettingwidget.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "shortcutsettingwidget.h"
+#include "shortcutedit.h"
 #include "common/common.h"
 
 #include <DLabel>
@@ -71,7 +72,7 @@ void ShortCut::updateUi()
         QString description = valueList.first();
         QString shortcut = valueList.last();
 
-        auto keyEdit = new DKeySequenceEdit(this);
+        auto keyEdit = new ShortCutEdit(this);
         keyEdit->setKeySequence(QKeySequence(shortcut));
         keyEdit->setFixedWidth(300);
         keyEdit->ShortcutDirection(Qt::AlignLeft);
@@ -87,6 +88,9 @@ void ShortCut::updateUi()
         hlayout->setAlignment(keyEdit, Qt::AlignRight);
 
         d->bgGplayout->addWidget(wrapper);
+        connect(keyEdit, &ShortCutEdit::shortcutCleared, [=]() {
+            updateShortcut(id, "");
+        });
         connect(keyEdit, &DKeySequenceEdit::editingFinished, this, [=](const QKeySequence &sequence) {
             bool inValid = keySequenceIsInvalid(sequence);
             QString oldShortcut = d->shortcutItemMap.value(id).last();


### PR DESCRIPTION
Log: Fixed that shortcut keys could not be cancelled, added right-click menu to cancel shortcut keys

Bug: https://pms.uniontech.com/bug-view-246835.html