### PR TITLE
fix: [builder] build failed when build parameters used

### DIFF
--- a/src/plugins/cxx/cmake/project/properties/bulidCfgWidget/stepspane.cpp
+++ b/src/plugins/cxx/cmake/project/properties/bulidCfgWidget/stepspane.cpp
@@ -276,7 +276,7 @@ void StepsPane::updateSummaryText()
 
 void StepsPane::setValues(const config::StepItem &item)
 {
-    d->toolArguments->setText(item.buildArguments);
+    d->toolArguments->setText(item.buildArguments.join(" "));
 
     QMap<QString, bool> data;
     foreach (auto targetName, item.allTargetNames) {
@@ -289,6 +289,6 @@ void StepsPane::setValues(const config::StepItem &item)
 
 void StepsPane::getValues(config::StepItem &item)
 {
-    item.buildArguments = d->toolArguments->text();
+    item.buildArguments = d->toolArguments->text().split(" ");
     item.activeTargetName = d->model->getSelectedTarget();
 }

--- a/src/plugins/cxx/cmake/project/properties/configWidget/configureprojpane.cpp
+++ b/src/plugins/cxx/cmake/project/properties/configWidget/configureprojpane.cpp
@@ -187,7 +187,7 @@ void ConfigureProjPane::slotConfigure()
             // default use max thread count
             int coreCount = QThread::idealThreadCount();
             if (coreCount > 1) {
-                item.buildArguments = QString("-j%1").arg(coreCount);
+                item.buildArguments << QString("-j%1").arg(coreCount);
             }
             buildTypeConfigure.buildConfigure.steps.push_back(item);
         }

--- a/src/plugins/cxx/cmake/project/properties/configutil.h
+++ b/src/plugins/cxx/cmake/project/properties/configutil.h
@@ -29,7 +29,7 @@ struct StepItem {
     StepType type = Build;
     QString activeTargetName;
     QStringList allTargetNames;
-    QString buildArguments;
+    QStringList buildArguments;
 
     friend QDataStream &operator<<(QDataStream &stream, const StepItem &data)
     {


### PR DESCRIPTION
Use QStringList for build arguments, same as in steps pane

Log: bug fix
Change-Id: I8831a8be8d9103511dd54d3085146b3a17f7db5a