### PR TITLE
fix: [template] can't debug default template

### DIFF
--- a/assets/templates/projects/cmake/console/CMakeLists.txt
+++ b/assets/templates/projects/cmake/console/CMakeLists.txt
@@ -3,4 +3,9 @@ cmake_minimum_required(VERSION 2.8)
 project(%{ProjectName})
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+if(${CMAKE_MAJOR_VERSION} LESS 3 OR (${CMAKE_MAJOR_VERSION} EQUAL 3 AND ${CMAKE_MINOR_VERSION} LESS 16))
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+    message(STATUS "Adding -g to CXX_FLAGS because CMake is less than 3.16")
+endif()
+
 add_executable(${PROJECT_NAME} "main.cpp")


### PR DESCRIPTION
Log: add "-g" compile option while the cmake version less than 3.16

Bug: https://pms.uniontech.com/bug-view-255883.html