### PR TITLE
fix: [dapdebugger] crash when close ide

### DIFF
--- a/src/plugins/debugger/dap/dapdebugger.cpp
+++ b/src/plugins/debugger/dap/dapdebugger.cpp
@@ -59,6 +59,7 @@ using DTK_WIDGET_NAMESPACE::DSpinner;
 class DebuggerPrivate
 {
     friend class DAPDebugger;
+    ~DebuggerPrivate();
 
     QString activeProjectKitName;
     dpfservice::ProjectInfo projectInfo;
@@ -115,6 +116,13 @@ class DebuggerPrivate
     RemoteInfo remoteInfo;
 };
 
+DebuggerPrivate::~DebuggerPrivate() {
+    if (alertBox)
+        delete alertBox;
+    if (variablesPane)
+        delete variablesPane;
+}
+
 DAPDebugger::DAPDebugger(QObject *parent)
     : AbstractDebugger(parent)
     , d(new DebuggerPrivate())
@@ -155,14 +163,7 @@ DAPDebugger::DAPDebugger(QObject *parent)
 
 DAPDebugger::~DAPDebugger()
 {
-    delete d->alertBox;
-    if (d)
-        delete d;
-    if (d->variablesPane)
-        delete d->variablesPane;
-    if (d->debugMainPane)
-        delete d->debugMainPane;
-    // all widgets in tabWidget will be deleted automatically.
+    delete d;
 }
 
 DWidget *DAPDebugger::getOutputPane() const


### PR DESCRIPTION
log: issue of memory release