### PR TITLE
fix: [project] executing program is not the program of the activated …

### DIFF
--- a/src/plugins/cxx/cmake/project/cmakeprojectgenerator.cpp
+++ b/src/plugins/cxx/cmake/project/cmakeprojectgenerator.cpp
@@ -449,6 +449,10 @@ void CmakeProjectGenerator::actionProperties(const dpfservice::ProjectInfo &info
 {
     PropertiesDialog dlg;
 
+    //update config by current project(not activated project
+    ProjectConfigure *projectConfigure = ConfigUtil::instance()->getConfigureParamPointer();
+    ConfigUtil::instance()->readConfig(ConfigUtil::instance()->getConfigPath(info.workspaceFolder()), *projectConfigure);
+
     BuildPropertyPage *buildWidget = new BuildPropertyPage(info);
     RunPropertyPage *runWidget = new RunPropertyPage(info, item);
 


### PR DESCRIPTION
…project.

When Project B is active, clicking on the project properties of Project A will open the properties of Project B. Saving at this point will cause the properties of Project A to be erroneous.”

log: