### PR TITLE
fix: [core] can't expand when tapping the context widget tab

### DIFF
--- a/src/plugins/core/uicontroller/controller.cpp
+++ b/src/plugins/core/uicontroller/controller.cpp
@@ -486,6 +486,10 @@ void Controller::switchContextWidget(const QString &title)
 {
     qInfo() << __FUNCTION__;
     d->stackContextWidget->setCurrentWidget(d->contextWidgets[title]);
+    if (d->stackContextWidget->isHidden()) {
+        d->contextWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+        d->stackContextWidget->show();
+    }
     if (d->tabButtons.contains(title))
         d->tabButtons[title]->show();
 


### PR DESCRIPTION
Fixed an issue where the contextwidget would not expand when the contextwidget tab was clicked when the dockwidget was hidden Log: fix an issue