### PR TITLE
fix: [console] removeButton should be disabled

### DIFF
--- a/src/plugins/console/consolemanager.h
+++ b/src/plugins/console/consolemanager.h
@@ -25,7 +25,6 @@ private:
     void appendConsole();
     void removeConsole();
     void switchConsole(const QModelIndex &index);
-    void showDialog(const QString &msg);
     void showEvent(QShowEvent *event) override;
 
     ConsoleManagerPrivate *d;


### PR DESCRIPTION
fixed removeButton should be disabled while activating only one console