### PR TITLE
fix: [translations] translations issue of breakpoint`s view

### DIFF
--- a/src/plugins/debugger/interface/breakpointview.h
+++ b/src/plugins/debugger/interface/breakpointview.h
@@ -15,6 +15,7 @@ class EditorService;
 
 class BreakpointView : public DTK_WIDGET_NAMESPACE::DTreeView
 {
+    Q_OBJECT
 public:
     explicit BreakpointView(QWidget *parent = nullptr);
     ~BreakpointView();


### PR DESCRIPTION
Log: as title