### PR TITLE
fix: [pluginmanager] crash when open optionsdialog in plugins

### DIFF
--- a/src/plugins/option/optioncore/mainframe/optionsdialog.cpp
+++ b/src/plugins/option/optioncore/mainframe/optionsdialog.cpp
@@ -90,7 +90,10 @@ void OptionsDialog::showAtItem(const QString &itemName)
 {
     show();
 
-    QModelIndex index = leftBarModel->indexFromItem(leftBarModel->findItems(itemName).at(0));
+    auto targetItems = leftBarModel->findItems(itemName);
+    QModelIndex index = leftBarModel->index(0, 0);
+    if (!targetItems.isEmpty())
+        index = leftBarModel->indexFromItem(targetItems.at(0));
     slotLeftBarClicked(index);
 }
 


### PR DESCRIPTION
Log: as title