### PR TITLE
fix: Reset the shortcut key search status when close the Settings dialog

### DIFF
--- a/src/plugins/option/optioncore/mainframe/shortcutsettingwidget.cpp
+++ b/src/plugins/option/optioncore/mainframe/shortcutsettingwidget.cpp
@@ -640,3 +640,13 @@ void ShortcutSettingWidget::saveConfig()
     d->apply();
     ActionManager::instance()->saveSettings();
 }
+
+void ShortcutSettingWidget::hideEvent(QHideEvent *e)
+{
+    if (d->recordKeyBtn->isChecked()) {
+        d->recordKeyBtn->setChecked(false);
+        d->searchEdit->setPlaceholderText(tr("Type to search in keybindings"));
+    }
+    d->searchEdit->clearEdit();
+    PageWidget::hideEvent(e);
+}

--- a/src/plugins/option/optioncore/mainframe/shortcutsettingwidget.h
+++ b/src/plugins/option/optioncore/mainframe/shortcutsettingwidget.h
@@ -27,6 +27,9 @@ public:
     void readConfig() override;
     void saveConfig() override;
 
+protected:
+    void hideEvent(QHideEvent *e) override;
+
 private:
     ShortcutSettingWidgetPrivate *const d;
 };


### PR DESCRIPTION
as title

Bug: https://pms.uniontech.com/bug-view-277235.html
Bug: https://pms.uniontech.com/bug-view-277115.html
Log: fix bug
