### PR TITLE
fix: [InlineChat] Fixed an issue where the inline chat dialog could not exit

### DIFF
--- a/src/plugins/codeeditor/gui/texteditor.cpp
+++ b/src/plugins/codeeditor/gui/texteditor.cpp
@@ -786,7 +786,7 @@ bool TextEditor::showLineWidget(int line, QWidget *widget)
     if (line == 0)
         line += 1;
 
-    if (line < 0 || line >= lines() || !hasFocus())
+    if (line < 0 || line >= lines())
         return false;
 
     if (d->lineWidgetContainer->isVisible())
@@ -893,6 +893,9 @@ void TextEditor::keyPressEvent(QKeyEvent *event)
 {
     if (event->key() == Qt::Key_Tab && d->cpCache.first != -1)
         return applyCompletion();
+    
+    if (event->key() == Qt::Key_Escape && d->lineWidgetContainer->isVisible())
+        return closeLineWidget();
 
     if (d->completionWidget->processKeyPressEvent(event))
         return;


### PR DESCRIPTION
When the focus is in the editor, cannot exit the dialog through Esc

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-277671.html
