### PR TITLE
refactor: [settings] migrate config storage to unified settings system

### DIFF
--- a/src/common/settings/settings.cpp
+++ b/src/common/settings/settings.cpp
@@ -210,7 +210,7 @@ void Settings::setValue(const QString &group, const QString &key, const QVariant
     if (d->isRemovable(group, key)) {
         changed = d->settingData.value(group, key) != value;
     } else {
-        changed = this->value(group, key, value) != value;
+        changed = this->value(group, key) != value;
     }
 
     if (!changed)

--- a/src/plugins/codegeex/option/codegeexoptionwidget.cpp
+++ b/src/plugins/codegeex/option/codegeexoptionwidget.cpp
@@ -31,7 +31,7 @@ CodeGeeXOptionWidget::CodeGeeXOptionWidget(QWidget *parent)
     d->tabWidget->setDocumentMode(true);
     layout->addWidget(d->tabWidget);
 
-    d->tabWidget->addTab(new DetailWidget(), tr("CodeGeeX"));
+    d->tabWidget->addTab(new DetailWidget(), "Detail");
     QObject::connect(d->tabWidget, &DTabWidget::currentChanged, [this]() {
         readConfig();
     });

--- a/src/plugins/codegeex/option/detailwidget.cpp
+++ b/src/plugins/codegeex/option/detailwidget.cpp
@@ -111,26 +111,22 @@ void DetailWidget::setControlValue(const QMap<QString, QVariant> &map)
 
 bool DetailWidget::dataToMap(const CodeGeeXConfig &config, QMap<QString, QVariant> &map)
 {
-    QMap<QString, QVariant> apiKey;
-    apiKey.insert(kCodeCompletion, config.codeCompletionEnabled);
-    apiKey.insert(kGlobalLanguage, config.globalLanguage);
-    apiKey.insert(kCommitsLanguage, config.commitsLanguage);
-
-    map.insert("Detail", apiKey);
+    map.insert(kCodeCompletion, config.codeCompletionEnabled);
+    map.insert(kGlobalLanguage, config.globalLanguage);
+    map.insert(kCommitsLanguage, config.commitsLanguage);
 
     return true;
 }
 
 bool DetailWidget::mapToData(const QMap<QString, QVariant> &map, CodeGeeXConfig &config)
 {
-    QMap<QString, QVariant> detail = map.value("Detail").toMap();
-    auto var = detail.value(kCodeCompletion);
+    auto var = map.value(kCodeCompletion);
     if (var.isValid())
         config.codeCompletionEnabled = var.toBool();
-    var = detail.value(kGlobalLanguage);
+    var = map.value(kGlobalLanguage);
     if (var.isValid())
         config.globalLanguage = var.value<CodeGeeX::locale>();
-    var = detail.value(kCommitsLanguage);
+    var = map.value(kCommitsLanguage);
     if (var.isValid())
         config.commitsLanguage = var.value<CodeGeeX::locale>();
 


### PR DESCRIPTION
Refactored configuration storage mechanism across multiple components to use
the unified settings system:

- Migrated language settings from file-based to settings-based storage
- Updated CodeGeeX configuration to use OptionManager
- Refactored profile settings to use centralized storage
- Added compatibility code for smooth transition from old storage format
- Cleaned up deprecated file-based storage methods

The changes improve configuration management consistency and maintainability
by centralizing all settings into a single system.

Log: refactored configuration storage to use unified settings system
