### PR TITLE
fix: [session] improve session management and UI interaction

### DIFF
--- a/src/plugins/core/session/sessiondialog.cpp
+++ b/src/plugins/core/session/sessiondialog.cpp
@@ -192,6 +192,7 @@ void SessionNameInputDialog::initUI()
     addButton("3", true, DDialog::ButtonRecommend);
     getButton(1)->setEnabled(false);
     getButton(2)->setEnabled(false);
+    setFocusProxy(lineEdit);
 }
 
 void SessionNameInputDialog::setSessionName(const QString &name)

--- a/src/plugins/core/session/sessionlistview.h
+++ b/src/plugins/core/session/sessionlistview.h
@@ -29,6 +29,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void sessionsSelected(const QStringList &sessions);
+    void sessionCreated(const QString &session);
 
 private:
     void initUI();

--- a/src/plugins/core/session/sessionmanager.cpp
+++ b/src/plugins/core/session/sessionmanager.cpp
@@ -227,7 +227,8 @@ bool SessionManager::cloneSession(const QString &select, const QString &clone)
 
 void SessionManager::showSessionManager()
 {
-    saveSession();
+    if (!isDefaultVirgin())
+        saveSession();
     SessionDialog dlg(Controller::instance()->mainWindow());
     dlg.setAutoLoadSession(d->isAutoLoad);
     dlg.exec();

--- a/src/plugins/project/mainframe/projecttree.cpp
+++ b/src/plugins/project/mainframe/projecttree.cpp
@@ -105,7 +105,7 @@ ProjectTree::~ProjectTree()
     }
 }
 
-void ProjectTree::clear()
+void ProjectTree::closeAllProjects()
 {
     while (auto item = d->itemModel->item(0)) {
         removeRootItem(item);

--- a/src/plugins/project/mainframe/projecttree.h
+++ b/src/plugins/project/mainframe/projecttree.h
@@ -21,7 +21,7 @@ class ProjectTree : public DTreeView
 public:
     explicit ProjectTree(QWidget *parent = nullptr);
     ~ProjectTree() override;
-    void clear();
+    void closeAllProjects();
     void activeProjectInfo(const dpfservice::ProjectInfo &info);
     void activeProjectInfo(const QString &workspace);
     void appendRootItem(QStandardItem *root);

--- a/src/plugins/project/transceiver/projectcorereceiver.cpp
+++ b/src/plugins/project/transceiver/projectcorereceiver.cpp
@@ -117,9 +117,10 @@ void ProjectCoreReceiver::processOpenProjectByPathEvent(const dpf::Event &event)
 
 void ProjectCoreReceiver::processSessionLoadedEvent(const dpf::Event &event)
 {
+    uiController.doSwitch(dpfservice::MWNA_EDIT);
     auto sessionSrv = dpfGetService(SessionService);
     auto view = ProjectKeeper::instance()->treeView();
-    view->clear();
+    view->closeAllProjects();
 
     auto prjList = sessionSrv->value("ProjectList").toList();
     for (const auto &info : prjList) {

--- a/src/plugins/recent/mainframe/sessionitemwidget.cpp
+++ b/src/plugins/recent/mainframe/sessionitemwidget.cpp
@@ -447,17 +447,16 @@ void SessionItemListWidget::addSessionList(const QStringList &sessionList)
 
 void SessionItemListWidget::removeSession(const QString &session)
 {
-    auto iter = std::find_if(sessionList.begin(), sessionList.end(),
-                             [&session](SessionItemWidget *item) {
-                                 return item->sessionName() == session;
-                             });
-    if (iter == sessionList.end())
-        return;
-
-    sessionList.removeOne(*iter);
-    mainLayout->removeWidget(*iter);
-    (*iter)->deleteLater();
-    updateSessions();
+    for (auto *item : sessionList) {
+        if (item->sessionName() == session) {
+            sessionList.removeOne(item);
+            mainLayout->removeWidget(item);
+            item->deleteLater();
+            item = nullptr;
+            updateSessions();
+            break;
+        }
+    }
 }
 
 void SessionItemListWidget::updateSessions()


### PR DESCRIPTION
- Fix session clone operation by using correct cloneSession instead of rename
- Improve session deletion handling with keyboard support
- Optimize session list widget removal logic
- Add session created signal and connection
- Change project tree clear method name to closeAllProjects for clarity
- Add UI switch to edit mode when loading session
- Only save session when not in default virgin state

Log: fix session management issues and enhance user interaction
