### PR TITLE
refactor: [project] Optimize project tree icon loading and parsing

### DIFF
--- a/src/plugins/cxx/cmake/project/cmakeasynparse.h
+++ b/src/plugins/cxx/cmake/project/cmakeasynparse.h
@@ -17,7 +17,7 @@ class CMakeCbpParser;
 namespace {
 enum_def(CDT_PROJECT_KIT, QString)
 {
-    enum_exp CBP_GENERATOR = "CodeBlocks - Unix Makefiles";   
+    enum_exp CBP_GENERATOR = "CodeBlocks - Unix Makefiles";
     enum_exp CBP_FILE = ".cbp";
 };
 
@@ -53,25 +53,30 @@ public:
         QString stopOnError;
         QString useDefaultCommand;
     };
-
     typedef QList<TargetBuild> TargetBuilds;
 
     CmakeAsynParse();
     virtual ~CmakeAsynParse();
 
+    void stop();
+
 signals:
     void parseProjectEnd(const ParseInfo<QStandardItem *> &info);
     void parseActionsEnd(const ParseInfo<QList<TargetBuild>> &info);
-    void directoryCreated(const QString &path);
+    void directoryCreated(QStandardItem *rootItem, const QString &path);
 
 public slots:
-    QStandardItem *parseProject(QStandardItem *rootItem, const dpfservice::ProjectInfo &info);
+    void parseProject(QStandardItem *rootItem, const dpfservice::ProjectInfo &info);
     QList<TargetBuild> parseActions(const QStandardItem *item);
 
 private:
     QStandardItem *findParentItem(QStandardItem *rootItem, QString &name);
     QStandardItem *createParentItem(QStandardItem *rootItem, const QString &relativeName, const QString &absolutePath);
     QStandardItem *findItem(QStandardItem *rootItem, QString &name, QString &relativePath);
+
+    QAtomicInteger<bool> isStop { false };
 };
 
+Q_DECLARE_METATYPE(CmakeAsynParse::ParseInfo<QStandardItem *>)
+Q_DECLARE_METATYPE(CmakeAsynParse::ParseInfo<QList<CmakeAsynParse::TargetBuild>>)
 #endif   // CMAKEASYNPARSE_H

--- a/src/plugins/cxx/cmake/project/cmakeprojectgenerator.h
+++ b/src/plugins/cxx/cmake/project/cmakeprojectgenerator.h
@@ -8,6 +8,7 @@
 #include "services/project/projectservice.h"
 #include "services/builder/builderservice.h"
 #include "configutil.h"
+#include "cmakeasynparse.h"
 
 #include <QObject>
 #include <QDomDocument>
@@ -43,8 +44,10 @@ private slots:
     void actionProperties(const dpfservice::ProjectInfo &info, QStandardItem *item);
     void recursionRemoveItem(QStandardItem *item);
     void targetInitialized(const QString& workspace);
+    void projectParseFinished(const CmakeAsynParse::ParseInfo<QStandardItem *> &info);
 
 private:
+    void initCMakeParser();
     void createTargetsRunConfigure(const QString &workDirectory, config::RunConfigure &runConfigure);
     void createBuildMenu(QMenu *menu);
     void clearCMake(QStandardItem *root);

--- a/src/plugins/java/gradle/project/gradleasynparse.cpp
+++ b/src/plugins/java/gradle/project/gradleasynparse.cpp
@@ -6,6 +6,7 @@
 #include "services/project/projectgenerator.h"
 
 #include "common/common.h"
+#include "services/project/projectservice.h"
 
 #include <QAction>
 #include <QDebug>
@@ -92,8 +93,8 @@ void GradleAsynParse::createRows(const QString &path)
             QString childPath = dirItera.next().remove(0, rootPath.size());
             QFileSystemWatcher::addPath(dirItera.filePath());
             QStandardItem *item = findItem(childPath);
-            QIcon icon = CustomIcons::icon(dirItera.fileInfo());
-            auto newItem = new QStandardItem(icon, dirItera.fileName());
+            auto newItem = new QStandardItem(dirItera.fileName());
+            newItem->setData(dirItera.filePath(), ProjectItemRole::FileIconRole);
             newItem->setToolTip(dirItera.filePath());
             if (!item) {
                 d->rows.append(newItem);
@@ -111,8 +112,8 @@ void GradleAsynParse::createRows(const QString &path)
         while (fileItera.hasNext()) {
             QString childPath = fileItera.next().remove(0, rootPath.size());
             QStandardItem *item = findItem(childPath);
-            QIcon icon = CustomIcons::icon(fileItera.fileInfo());
-            auto newItem = new QStandardItem(icon, fileItera.fileName());
+            auto newItem = new QStandardItem(fileItera.fileName());
+            newItem->setData(fileItera.filePath(), ProjectItemRole::FileIconRole);
             newItem->setToolTip(fileItera.filePath());
             if (!item) {
                 d->rows.append(newItem);

--- a/src/plugins/java/gradle/project/gradleprojectgenerator.cpp
+++ b/src/plugins/java/gradle/project/gradleprojectgenerator.cpp
@@ -235,7 +235,7 @@ void GradleProjectGenerator::doProjectChildsModified(const QList<QStandardItem *
         }
         rootItem->appendRows(items);
     }
-    rootItem->setData(ParsingState::Done, Parsing_State_Role);
+    rootItem->setData(ParsingState::Done, ProjectItemRole::ParsingStateRole);
 }
 
 void GradleProjectGenerator::doGradleGeneratMenu(const QString &program,

--- a/src/plugins/java/maven/project/mavenasynparse.cpp
+++ b/src/plugins/java/maven/project/mavenasynparse.cpp
@@ -5,6 +5,7 @@
 #include "mavenasynparse.h"
 #include "services/project/projectgenerator.h"
 #include "services/option/optionmanager.h"
+#include "services/project/projectservice.h"
 
 #include "common/common.h"
 
@@ -136,8 +137,8 @@ void MavenAsynParse::createRows(const QString &path)
             QString childPath = dirItera.next().remove(0, rootPath.size());
             QFileSystemWatcher::addPath(dirItera.filePath());
             QStandardItem *item = findItem(childPath);
-            QIcon icon = CustomIcons::icon(dirItera.fileInfo());
-            auto newItem = new QStandardItem(icon, dirItera.fileName());
+            auto newItem = new QStandardItem(dirItera.fileName());
+            newItem->setData(dirItera.filePath(), ProjectItemRole::FileIconRole);
             newItem->setToolTip(dirItera.filePath());
             if (!item) {
                 d->rows.append(newItem);
@@ -155,8 +156,8 @@ void MavenAsynParse::createRows(const QString &path)
         while (fileItera.hasNext()) {
             QString childPath = fileItera.next().remove(0, rootPath.size());
             QStandardItem *item = findItem(childPath);
-            QIcon icon = CustomIcons::icon(fileItera.fileInfo());
-            auto newItem = new QStandardItem(icon, fileItera.fileName());
+            auto newItem = new QStandardItem(fileItera.fileName());
+            newItem->setData(fileItera.filePath(), ProjectItemRole::FileIconRole);
             newItem->setToolTip(fileItera.filePath());
             if (!item) {
                 d->rows.append(newItem);

--- a/src/plugins/java/maven/project/mavenprojectgenerator.cpp
+++ b/src/plugins/java/maven/project/mavenprojectgenerator.cpp
@@ -177,7 +177,7 @@ void MavenProjectGenerator::itemModified(const QList<QStandardItem *> &items)
     if (parse) {
         auto root = d->projectParses.key(parse);
         emit itemChanged(root, items);
-        root->setData(ParsingState::Done, Parsing_State_Role);
+        root->setData(ParsingState::Done, ProjectItemRole::ParsingStateRole);
     }
 }
 

--- a/src/plugins/project/mainframe/projectdelegate.cpp
+++ b/src/plugins/project/mainframe/projectdelegate.cpp
@@ -54,10 +54,10 @@ void ProjectDelegate::paint(QPainter *painter,
         iOption.font.setBold(true);
         d->spinner->move(option.rect.right() - 20, option.rect.top() + 4);
 
-        if (index.data(Parsing_State_Role).value<ParsingState>() == ParsingState::Wait && !d->spinner->isVisible()) {
+        if (index.data(ProjectItemRole::ParsingStateRole).value<ParsingState>() == ParsingState::Wait && !d->spinner->isVisible()) {
             d->spinner->show();
             d->spinner->start();
-        } else if (index.data(Parsing_State_Role).value<ParsingState>() == ParsingState::Done) {
+        } else if (index.data(ProjectItemRole::ParsingStateRole).value<ParsingState>() == ParsingState::Done) {
             d->spinner->hide();
             d->spinner->stop();
         }

--- a/src/plugins/project/mainframe/projectmodel.cpp
+++ b/src/plugins/project/mainframe/projectmodel.cpp
@@ -4,8 +4,27 @@
 
 #include "projectmodel.h"
 
-ProjectModel::ProjectModel(QObject *parent)
-    : QStandardItemModel (parent)
-{
+#include "common/util/customicons.h"
+#include "services/project/projectservice.h"
 
+#include <QDebug>
+
+ProjectModel::ProjectModel(QObject *parent)
+    : QStandardItemModel(parent)
+{
+}
+
+QVariant ProjectModel::data(const QModelIndex &index, int role) const
+{
+    if (role == Qt::DecorationRole) {
+        auto name = index.data(ProjectItemRole::IconNameRole).toString();
+        if (!name.isEmpty())
+            return QIcon::fromTheme(name);
+
+        name = index.data(ProjectItemRole::FileIconRole).toString();
+        if (!name.isEmpty())
+            return CustomIcons::icon(QFileInfo(name));
+    }
+
+    return QStandardItemModel::data(index, role);
 }

--- a/src/plugins/project/mainframe/projectmodel.h
+++ b/src/plugins/project/mainframe/projectmodel.h
@@ -11,6 +11,8 @@ class ProjectModel : public QStandardItemModel
     Q_OBJECT
 public:
     explicit ProjectModel(QObject *parent = nullptr);
+    
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 };
 
 #endif // PROJECTMODEL_H

--- a/src/plugins/project/mainframe/projecttree.cpp
+++ b/src/plugins/project/mainframe/projecttree.cpp
@@ -156,8 +156,8 @@ void ProjectTree::appendRootItem(QStandardItem *root)
     if (model)
         model->appendRow(root);
 
-    if (root->data(Parsing_State_Role).value<ParsingState>() != ParsingState::Done)   //avoid appent root item after complete parse
-        root->setData(ParsingState::Wait, Parsing_State_Role);
+    if (root->data(ProjectItemRole::ParsingStateRole).value<ParsingState>() != ParsingState::Done)   //avoid appent root item after complete parse
+        root->setData(ParsingState::Wait, ProjectItemRole::ParsingStateRole);
 
     // 发送工程节点已创建信号
     SendEvents::projectCreated(info);

--- a/src/services/project/directoryasynparse.cpp
+++ b/src/services/project/directoryasynparse.cpp
@@ -6,6 +6,7 @@
 #include "projectgenerator.h"
 
 #include "common/common.h"
+#include "services/project/projectservice.h"
 
 #include <QAction>
 
@@ -84,8 +85,8 @@ void DirectoryAsynParse::createRows(const QString &path)
             QString childPath = dirItera.next().remove(0, rootPath.size());
             QFileSystemWatcher::addPath(dirItera.filePath());
             QStandardItem *item = findItem(childPath);
-            QIcon icon = CustomIcons::icon(dirItera.fileInfo());
-            auto newItem = new QStandardItem(icon, dirItera.fileName());
+            auto newItem = new QStandardItem(dirItera.fileName());
+            newItem->setData(dirItera.filePath(), ProjectItemRole::FileIconRole);
             newItem->setToolTip(dirItera.filePath());
             if (!item) {
                 d->rows.append(newItem);
@@ -103,8 +104,8 @@ void DirectoryAsynParse::createRows(const QString &path)
         while (fileItera.hasNext()) {
             QString childPath = fileItera.next().remove(0, rootPath.size());
             QStandardItem *item = findItem(childPath);
-            QIcon icon = CustomIcons::icon(fileItera.fileInfo());
-            auto newItem = new QStandardItem(icon, fileItera.fileName());
+            auto newItem = new QStandardItem(fileItera.fileName());
+            newItem->setData(fileItera.filePath(), ProjectItemRole::FileIconRole);
             newItem->setToolTip(fileItera.filePath());
             if (!item) {
                 d->rows.append(newItem);

--- a/src/services/project/directorygenerator.cpp
+++ b/src/services/project/directorygenerator.cpp
@@ -113,5 +113,5 @@ void DirectoryGenerator::doProjectChildsModified(const QList<QStandardItem *> &i
         rootItem->appendRows(info);
     }
 
-    rootItem->setData(ParsingState::Done, Parsing_State_Role);
+    rootItem->setData(ParsingState::Done, ProjectItemRole::ParsingStateRole);
 }

--- a/src/services/project/projectservice.h
+++ b/src/services/project/projectservice.h
@@ -10,12 +10,17 @@
 
 #include <QTabWidget>
 
-#define Parsing_State_Role Qt::UserRole + 100
 enum ParsingState {
     Wait,
     Done
 };
 Q_DECLARE_METATYPE(ParsingState);
+
+enum ProjectItemRole {
+    ParsingStateRole = Qt::UserRole + 100,
+    IconNameRole,
+    FileIconRole
+};
 
 namespace dpfservice {
 


### PR DESCRIPTION
Refactored project tree icon loading mechanism and parsing process to improve
performance and maintainability:

- Moved icon loading from individual items to ProjectModel data() method
- Added ProjectItemRole enum for icon name and file path roles
- Replaced direct icon setting with role-based data storage
- Implemented stop mechanism for cmake async parsing
- Moved cmake parser to separate thread for better responsiveness
- Unified parsing state role usage across project types
- Removed redundant icon loading code from various parsers
- Added sorting capability to project tree

Log: Optimize project tree icon loading and parsing mechanism
