### PR TITLE
fix: [find] improve search result display and parsing

### DIFF
--- a/src/plugins/codeeditor/statusbar/encodecombobox.cpp
+++ b/src/plugins/codeeditor/statusbar/encodecombobox.cpp
@@ -6,6 +6,7 @@
 #include "utils/editorutils.h"
 
 #include <DStyle>
+#include <DGuiApplicationHelper>
 #ifdef DTKWIDGET_CLASS_DPaletteHelper
 #include <DPaletteHelper>
 #else
@@ -49,6 +50,8 @@ void EncodeComboBox::initConnection()
         if (curEncodeName != action->text())
             Q_EMIT encodeChanged(action->text());
     });
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, [this] { toolBtn->setIcon(createIcon()); });
 }
 
 void EncodeComboBox::initMenuData()

--- a/src/plugins/find/gui/searchresultitemdelegate.h
+++ b/src/plugins/find/gui/searchresultitemdelegate.h
@@ -45,6 +45,9 @@ private:
     QTextLayout::FormatRange createFormatRange(const QStyleOptionViewItem &option, int start, int length,
                                                const QColor &foreground, const QColor &background) const;
     void drawIcon(QPainter *painter, const QStyleOptionViewItem &option, const QIcon &icon, const QRect &rect) const;
+    QPair<QString, QList<QTextLayout::FormatRange>> adjustContent(const QModelIndex &index,
+                                                                  const QString &originalText,
+                                                                  const QList<QTextLayout::FormatRange> &formatList) const;
 };
 
 #endif   // SEARCHRESULTITEMDELEGATE_H

--- a/src/plugins/find/gui/searchresultmodel.cpp
+++ b/src/plugins/find/gui/searchresultmodel.cpp
@@ -105,9 +105,11 @@ FindItem *SearchResultModel::findItem(const QModelIndex &index) const
 QString SearchResultModel::findGroup(const QModelIndex &index) const
 {
     if (index.isValid() && !index.parent().isValid() && index.column() == 0 && index.row() >= 0) {
-        const QList<QString> &keys = resultData.keys();
-        if (index.row() < keys.count())
-            return keys.at(index.row());
+        if (index.row() < resultData.count()) {
+            auto it = resultData.begin();
+            std::advance(it, index.row());
+            return it.key();
+        }
     }
 
     return QString();
@@ -117,16 +119,9 @@ void SearchResultModel::appendResult(const FindItemList &list)
 {
     QMap<QString, FindItemList> result;
     for (const auto &item : list) {
-        if (!resultData.contains(item.filePathName)) {
-            if (result.contains(item.filePathName)) {
-                addItem(item.filePathName, result[item.filePathName]);
-                result.clear();
-            }
+        if (!resultData.contains(item.filePathName))
             addGroup(item.filePathName);
-            result[item.filePathName].append(item);
-        } else {
-            result[item.filePathName].append(item);
-        }
+        result[item.filePathName].append(item);
     }
 
     for (auto iter = result.begin(); iter != result.end(); ++iter)
@@ -224,6 +219,7 @@ QVariant SearchResultModel::data(const FindItem &item, int role) const
 {
     switch (role) {
     case Qt::ToolTipRole:
+        return item.context.trimmed();
     case Qt::DisplayRole:
         return item.context;
     case LineRole:


### PR DESCRIPTION
Enhance search result handling and display in multiple aspects:
- Add content truncation for large search results to prevent parsing issues
- Optimize search result text display with proper trimming and formatting
- Improve regex pattern for parsing search results with non-greedy matching
- Add content side length limit for better readability
- Refactor result model to handle data updates more efficiently

The changes focus on improving stability and user experience when handling large search results, while maintaining performance.

Log: fix search result display and parsing issues
