### PR TITLE
refactor: [project] Improve directory parsing and expand state management

### DIFF
--- a/src/plugins/codeeditor/gui/tabwidget.cpp
+++ b/src/plugins/codeeditor/gui/tabwidget.cpp
@@ -378,6 +378,8 @@ void TabWidgetPrivate::onTabClosed(const QString &fileName)
     editorMng.remove(fileName);
     recentOpenedFiles.removeOne(fileName);
     editorLayout->removeWidget(editor);
+    if (!recentOpenedFiles.isEmpty())
+        q->openFile(recentOpenedFiles.first());
     changeFocusProxy();
 
     emit editor->fileClosed(fileName);

--- a/src/plugins/core/session/sessionmodel.cpp
+++ b/src/plugins/core/session/sessionmodel.cpp
@@ -83,7 +83,7 @@ void SessionModel::sort(int column, Qt::SortOrder order)
           [column, order](const QString &s1, const QString &s2) {
               bool ret = false;
               if (column == 0) {
-                  ret = s1 < s2;
+                  ret = s1.toLower() < s2.toLower();
               } else {
                   const auto &time1 = SessionManager::instance()->sessionDateTime(s1);
                   const auto &time2 = SessionManager::instance()->sessionDateTime(s2);

--- a/src/plugins/cxx/cmake/project/cmakeasynparse.cpp
+++ b/src/plugins/cxx/cmake/project/cmakeasynparse.cpp
@@ -186,7 +186,7 @@ void CmakeAsynParse::parseProject(QStandardItem *rootItem, const dpfservice::Pro
             cmakeFileItem->setText(cmakeFileInfo.fileName());
             cmakeFileItem->setToolTip(cmakeFileInfo.filePath());
             cmakeParentItem->appendRow(cmakeFileItem);
-            cmakeFileItem->setData(cmakeFileInfo.absoluteFilePath(), ProjectItemRole::FileIconRole);
+            cmakeFileItem->setData(cmakeFileInfo.absoluteFilePath(), Project::FileIconRole);
 
             // monitor cmake file change to refresh project tree.
             if (cmakeParentItem == rootItem) {
@@ -223,9 +223,9 @@ void CmakeAsynParse::parseProject(QStandardItem *rootItem, const dpfservice::Pro
             prefix = CDT_TARGETS_TYPE::get()->Lib;
         }
         if (target.type == kExecutable)
-            targetItem->setData("project_executable", ProjectItemRole::IconNameRole);
+            targetItem->setData("project_executable", Project::IconNameRole);
         else if (target.type == kStaticLibrary || target.type == kDynamicLibrary)
-            targetItem->setData("library", ProjectItemRole::IconNameRole);
+            targetItem->setData("library", Project::IconNameRole);
         QString title = prefix + target.title;
         targetItem->setText(title);
         targetItem->setToolTip(absolutePath);
@@ -259,7 +259,7 @@ void CmakeAsynParse::parseProject(QStandardItem *rootItem, const dpfservice::Pro
             QStandardItem *srcItem = new QStandardItem();
             srcItem->setText(srcFileInfo.fileName());
             srcItem->setToolTip(srcFileInfo.filePath());
-            srcItem->setData(srcFileInfo.absoluteFilePath(), ProjectItemRole::FileIconRole);
+            srcItem->setData(srcFileInfo.absoluteFilePath(), Project::FileIconRole);
             if (srcFileInfo.isDir())
                 emit directoryCreated(rootItem, srcFileInfo.filePath());
 
@@ -286,7 +286,7 @@ void CmakeAsynParse::parseProject(QStandardItem *rootItem, const dpfservice::Pro
     tempInfo.setCurrentProgram(TargetsManager::instance()->getActivedTargetByTargetType(TargetType::kActiveExecTarget).name);
     ProjectInfo::set(rootItem, tempInfo);
     emit parseProjectEnd({ rootItem, true });
-    rootItem->setData(ParsingState::Done, ProjectItemRole::ParsingStateRole);
+    rootItem->setData(Project::Done, Project::ParsingStateRole);
 }
 
 QList<CmakeAsynParse::TargetBuild> CmakeAsynParse::parseActions(const QStandardItem *item)
@@ -345,7 +345,7 @@ QStandardItem *CmakeAsynParse::createParentItem(QStandardItem *rootItem, const Q
             item = new QStandardItem();
             item->setText(nameItem);
             item->setToolTip(basePath + relative);
-            item->setData(basePath + relative, ProjectItemRole::FileIconRole);
+            item->setData(basePath + relative, Project::FileIconRole);
             // append to parent.
             QStandardItem *parentItem = findParentItem(rootItem, relative);
             emit directoryCreated(rootItem, basePath + relative);

--- a/src/plugins/cxx/cmake/project/cmakeprojectgenerator.cpp
+++ b/src/plugins/cxx/cmake/project/cmakeprojectgenerator.cpp
@@ -112,6 +112,7 @@ CmakeProjectGenerator::CmakeProjectGenerator()
 
     QObject::connect(runCMake, &QAction::triggered, this, [this]() {
         auto prjService = dpfGetService(ProjectService);
+
         auto activePrjInfo = prjService->getActiveProjectInfo();
         for (auto item : d->cmakeItems.values()) {
             if (item.isSame(activePrjInfo)) {
@@ -235,7 +236,7 @@ bool CmakeProjectGenerator::configure(const dpfservice::ProjectInfo &projInfo)
                 d->reConfigure = false;
             else {
                 d->reConfigure = true;
-                rootItem->setData(ParsingState::Wait, ProjectItemRole::ParsingStateRole);
+                rootItem->setData(Project::Wait, Project::ParsingStateRole);
             }
 
             d->cmakeItems.insert(newRoot, projInfo);

--- a/src/plugins/java/gradle/project/gradleasynparse.cpp
+++ b/src/plugins/java/gradle/project/gradleasynparse.cpp
@@ -94,7 +94,7 @@ void GradleAsynParse::createRows(const QString &path)
             QFileSystemWatcher::addPath(dirItera.filePath());
             QStandardItem *item = findItem(childPath);
             auto newItem = new QStandardItem(dirItera.fileName());
-            newItem->setData(dirItera.filePath(), ProjectItemRole::FileIconRole);
+            newItem->setData(dirItera.filePath(), Project::FileIconRole);
             newItem->setToolTip(dirItera.filePath());
             if (!item) {
                 d->rows.append(newItem);
@@ -113,7 +113,7 @@ void GradleAsynParse::createRows(const QString &path)
             QString childPath = fileItera.next().remove(0, rootPath.size());
             QStandardItem *item = findItem(childPath);
             auto newItem = new QStandardItem(fileItera.fileName());
-            newItem->setData(fileItera.filePath(), ProjectItemRole::FileIconRole);
+            newItem->setData(fileItera.filePath(), Project::FileIconRole);
             newItem->setToolTip(fileItera.filePath());
             if (!item) {
                 d->rows.append(newItem);

--- a/src/plugins/java/gradle/project/gradleprojectgenerator.cpp
+++ b/src/plugins/java/gradle/project/gradleprojectgenerator.cpp
@@ -235,7 +235,7 @@ void GradleProjectGenerator::doProjectChildsModified(const QList<QStandardItem *
         }
         rootItem->appendRows(items);
     }
-    rootItem->setData(ParsingState::Done, ProjectItemRole::ParsingStateRole);
+    rootItem->setData(Project::Done, Project::ParsingStateRole);
 }
 
 void GradleProjectGenerator::doGradleGeneratMenu(const QString &program,

--- a/src/plugins/java/maven/project/mavenasynparse.cpp
+++ b/src/plugins/java/maven/project/mavenasynparse.cpp
@@ -138,7 +138,7 @@ void MavenAsynParse::createRows(const QString &path)
             QFileSystemWatcher::addPath(dirItera.filePath());
             QStandardItem *item = findItem(childPath);
             auto newItem = new QStandardItem(dirItera.fileName());
-            newItem->setData(dirItera.filePath(), ProjectItemRole::FileIconRole);
+            newItem->setData(dirItera.filePath(), Project::FileIconRole);
             newItem->setToolTip(dirItera.filePath());
             if (!item) {
                 d->rows.append(newItem);
@@ -157,7 +157,7 @@ void MavenAsynParse::createRows(const QString &path)
             QString childPath = fileItera.next().remove(0, rootPath.size());
             QStandardItem *item = findItem(childPath);
             auto newItem = new QStandardItem(fileItera.fileName());
-            newItem->setData(fileItera.filePath(), ProjectItemRole::FileIconRole);
+            newItem->setData(fileItera.filePath(), Project::FileIconRole);
             newItem->setToolTip(fileItera.filePath());
             if (!item) {
                 d->rows.append(newItem);

--- a/src/plugins/java/maven/project/mavenprojectgenerator.cpp
+++ b/src/plugins/java/maven/project/mavenprojectgenerator.cpp
@@ -177,7 +177,7 @@ void MavenProjectGenerator::itemModified(const QList<QStandardItem *> &items)
     if (parse) {
         auto root = d->projectParses.key(parse);
         emit itemChanged(root, items);
-        root->setData(ParsingState::Done, ProjectItemRole::ParsingStateRole);
+        root->setData(Project::Done, Project::ParsingStateRole);
     }
 }
 

--- a/src/plugins/project/mainframe/projectdelegate.cpp
+++ b/src/plugins/project/mainframe/projectdelegate.cpp
@@ -54,10 +54,10 @@ void ProjectDelegate::paint(QPainter *painter,
         iOption.font.setBold(true);
         d->spinner->move(option.rect.right() - 20, option.rect.top() + 4);
 
-        if (index.data(ProjectItemRole::ParsingStateRole).value<ParsingState>() == ParsingState::Wait && !d->spinner->isVisible()) {
+        if (index.data(Project::ParsingStateRole).value<Project::ParsingState>() == Project::Wait && !d->spinner->isVisible()) {
             d->spinner->show();
             d->spinner->start();
-        } else if (index.data(ProjectItemRole::ParsingStateRole).value<ParsingState>() == ParsingState::Done) {
+        } else if (index.data(Project::ParsingStateRole).value<Project::ParsingState>() == Project::Done) {
             d->spinner->hide();
             d->spinner->stop();
         }

--- a/src/plugins/project/mainframe/projectmodel.cpp
+++ b/src/plugins/project/mainframe/projectmodel.cpp
@@ -17,11 +17,11 @@ ProjectModel::ProjectModel(QObject *parent)
 QVariant ProjectModel::data(const QModelIndex &index, int role) const
 {
     if (role == Qt::DecorationRole) {
-        auto name = index.data(ProjectItemRole::IconNameRole).toString();
+        auto name = index.data(Project::IconNameRole).toString();
         if (!name.isEmpty())
             return QIcon::fromTheme(name);
 
-        name = index.data(ProjectItemRole::FileIconRole).toString();
+        name = index.data(Project::FileIconRole).toString();
         if (!name.isEmpty())
             return CustomIcons::icon(QFileInfo(name));
     }

--- a/src/plugins/project/mainframe/projecttree.h
+++ b/src/plugins/project/mainframe/projecttree.h
@@ -29,6 +29,7 @@ public:
     void takeRootItem(QStandardItem *root);
     void expandedProjectDepth(const QStandardItem *root, int depth);
     void expandedProjectAll(const QStandardItem *root);
+    void restoreExpandState(QStandardItem *item);
     void selectProjectFile(const QString &file);
     void setAutoFocusState(bool state);
 	bool getAutoFocusState() const;

--- a/src/plugins/project/projectcore.cpp
+++ b/src/plugins/project/projectcore.cpp
@@ -218,6 +218,9 @@ void ProjectCore::initProject(dpf::PluginServiceContext &ctx)
         if (!projectService->getActiveProjectItem) {
             projectService->getActiveProjectItem = std::bind(&ProjectTree::getActiveProjectItem, treeView);
         }
+        if (!projectService->restoreExpandState) {
+            projectService->restoreExpandState = std::bind(&ProjectTree::restoreExpandState, treeView, _1);
+        }
     }
 }
 

--- a/src/plugins/recent/mainframe/recentdisplaywidget.cpp
+++ b/src/plugins/recent/mainframe/recentdisplaywidget.cpp
@@ -50,7 +50,6 @@ public:
 public:
     RecentDisplayWidget *q;
 
-    DWidget *recentOpen { nullptr };
     RecentListView *recentListView { nullptr };
     SessionItemListWidget *sessionListWidget { nullptr };
     DToolButton *recentClearBtn { nullptr };
@@ -271,7 +270,6 @@ void RecentDisplayWidget::clearRecent()
 
     if (isProAndDocNull()) {
         d->nullRecentText->setVisible(true);
-        d->recentOpen->setVisible(false);
     }
 }
 
@@ -316,8 +314,8 @@ void RecentDisplayWidget::initializeUi()
     proAndDocLayout->setSpacing(2);
     proAndDocLayout->addWidget(d->sessionFrame);
 
-    d->recentOpen = new DWidget(this);
-    QVBoxLayout *recentNavLayout = new QVBoxLayout(d->recentOpen);
+    QWidget *recentOpen = new QWidget(this);
+    QVBoxLayout *recentNavLayout = new QVBoxLayout(recentOpen);
     recentNavLayout->setContentsMargins(15, 0, 25, 20);
     recentNavLayout->addSpacing(25);
     recentNavLayout->setAlignment(Qt::AlignTop);
@@ -328,11 +326,10 @@ void RecentDisplayWidget::initializeUi()
     QHBoxLayout *hLayout = new QHBoxLayout(this);
     hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->addWidget(d->navFrame);
-    hLayout->addWidget(d->recentOpen);
+    hLayout->addWidget(recentOpen);
 
     if (!isProAndDocNull()) {
         d->nullRecentText->setVisible(false);
-        d->recentOpen->setVisible(true);
     }
 }
 
@@ -416,9 +413,7 @@ void RecentDisplayWidget::showEvent(QShowEvent *event)
 {
     if (!isProAndDocNull()) {
         d->nullRecentText->setVisible(false);
-        d->recentOpen->setVisible(true);
     } else {
         d->nullRecentText->setVisible(true);
-        d->recentOpen->setVisible(false);
     }
 }

--- a/src/services/project/directoryasynparse.h
+++ b/src/services/project/directoryasynparse.h
@@ -27,12 +27,14 @@ public:
         bool isNormal = true;
     };
 
-    DirectoryAsynParse();
-    QSet<QString> getFilelist();
+    explicit DirectoryAsynParse(QStandardItem *root);
     virtual ~DirectoryAsynParse();
 
+    QSet<QString> getFilelist();
+
 signals:
-    void itemsModified(const QList<QStandardItem *> &info);
+    void itemsModified();
+    void itemUpdated(QStandardItem *item);
     void parsedError(const ParseInfo<QString> &info);
 
 public slots:
@@ -43,10 +45,15 @@ private slots:
 
 private:
     void createRows(const QString &path);
-    QString itemDisplayName(const QStandardItem *item) const;
     QStandardItem *findItem(const QString &path, QStandardItem *parent = nullptr) const;
+    QStandardItem *findParentItem(const QString &path, QStandardItem *parent = nullptr) const;
     QList<QStandardItem *> rows(const QStandardItem *item) const;
-    int separatorSize() const;
+    QList<QStandardItem *> takeAll(QStandardItem *item);
+    void updateItem(QStandardItem *item);
+
+    void sortItems();
+    void sortChildren(QStandardItem *parentItem);
+    bool compareItems(QStandardItem *item1, QStandardItem *item2);
 };
 
 #endif   // DIRECTORYASYNPARSE_H

--- a/src/services/project/directorygenerator.h
+++ b/src/services/project/directorygenerator.h
@@ -25,10 +25,12 @@ public:
     virtual bool configure(const dpfservice::ProjectInfo &info = {}) override;
     virtual QStandardItem *createRootItem(const dpfservice::ProjectInfo &info) override;
     virtual void removeRootItem(QStandardItem *root) override;
+
 protected:
     dpfservice::ProjectInfo prjInfo;
 public slots:
-    void doProjectChildsModified(const QList<QStandardItem *> &info);
+    void doProjectChildsModified();
+    void handleItemUpdated(QStandardItem *item);
 };
 
 }

--- a/src/services/project/projectservice.h
+++ b/src/services/project/projectservice.h
@@ -10,21 +10,28 @@
 
 #include <QTabWidget>
 
+namespace Project {
+
 enum ParsingState {
     Wait,
     Done
 };
-Q_DECLARE_METATYPE(ParsingState);
 
 enum ProjectItemRole {
     ParsingStateRole = Qt::UserRole + 100,
     IconNameRole,
-    FileIconRole
+    FileIconRole,
+    FilePathRole,
+    ItemExpandedRole
 };
+}   // namespace project
+
+Q_DECLARE_METATYPE(Project::ParsingState);
 
 namespace dpfservice {
 
-struct Target {
+struct Target
+{
     QString name;
     QString srcPath;
     QString targetID;
@@ -42,7 +49,7 @@ struct Target {
     bool operator==(const Target &other) const
     {
         if (name == other.name
-                && srcPath == other.srcPath)
+            && srcPath == other.srcPath)
             return true;
 
         return false;
@@ -59,14 +66,15 @@ enum TargetType {
 };
 
 class SERVICE_EXPORT ProjectService final : public dpf::PluginService,
-        dpf::AutoServiceRegister<ProjectService>,
-        dpf::QtClassFactory<ProjectGenerator>,
-        dpf::QtClassManager<ProjectGenerator>
+                                            dpf::AutoServiceRegister<ProjectService>,
+                                            dpf::QtClassFactory<ProjectGenerator>,
+                                            dpf::QtClassManager<ProjectGenerator>
 {
     Q_OBJECT
     Q_DISABLE_COPY(ProjectService)
     typedef dpf::QtClassManager<ProjectGenerator> GeneratorProManager;
     typedef dpf::QtClassFactory<ProjectGenerator> GeneratorProFactory;
+
 public:
     static QString name()
     {
@@ -74,9 +82,8 @@ public:
     }
 
     explicit ProjectService(QObject *parent = nullptr)
-        : dpf::PluginService (parent)
+        : dpf::PluginService(parent)
     {
-
     }
 
     /*!
@@ -90,7 +97,7 @@ public:
             return GeneratorProFactory::createKeys();
         else {
             qCritical() << "must ProjectGenerator, "
-                        << "not support " << typeid (T).name();
+                        << "not support " << typeid(T).name();
             abort();
         }
     }
@@ -107,7 +114,7 @@ public:
             return GeneratorProFactory::regClass<T>(name, errorString);
         else {
             qCritical() << "must base class ProjectGenerator, "
-                        << "not support " << typeid (T).name();
+                        << "not support " << typeid(T).name();
             abort();
         }
     }
@@ -126,12 +133,12 @@ public:
             if (!generator) {
                 generator = GeneratorProFactory::create(name, errorString);
                 if (generator)
-                    GeneratorProManager::append(name, dynamic_cast<ProjectGenerator*>(generator));
+                    GeneratorProManager::append(name, dynamic_cast<ProjectGenerator *>(generator));
             }
-            return dynamic_cast<T*>(generator);
+            return dynamic_cast<T *>(generator);
         } else {
             qCritical() << "must base class or ProjectGenerator, "
-                        << "not support "<< typeid (T).name();
+                        << "not support " << typeid(T).name();
             abort();
         }
     }
@@ -140,12 +147,14 @@ public:
      * \brief name
      */
     template<class T>
-    QString name(T* value) const{
+    QString name(T *value) const
+    {
         return QtClassManager<T>::key(value);
     }
 
     template<class T>
-    QList<T*> values() const {
+    QList<T *> values() const
+    {
         return QtClassManager<T>::values();
     }
 
@@ -227,15 +236,16 @@ public:
      * \param aitem
      */
     DPF_INTERFACE(void, expandedAll, QStandardItem *aitem);
-    
+
     DPF_INTERFACE(void, openProject);
+    DPF_INTERFACE(void, restoreExpandState, QStandardItem *item);
 };
 
 /* MainWindow codeediter workspace title,
  * use in window service swtich workspace
  */
-inline const QString MWCWT_PROJECTS {QTabWidget::tr("Projects")};
+inline const QString MWCWT_PROJECTS { QTabWidget::tr("Projects") };
 
-} //namespace dpfservice
+}   //namespace dpfservice
 
-#endif // PROJECTSERVICE_H
+#endif   // PROJECTSERVICE_H


### PR DESCRIPTION
Refactored directory parsing implementation to improve performance and
maintainability. Major changes include:

- Replaced manual directory traversal with QDirIterator for better performance
- Added proper sorting of items (directories first, then case-insensitive)
- Implemented expand state persistence for project tree nodes
- Improved file monitoring and dynamic updates
- Cleaned up role definitions and moved them to Project namespace
- Streamlined signal/slot connections for item updates

Log: Refactored directory parsing and project tree management
