### PR TITLE
fix: [session] Add auto-close dialog after session switch

### DIFF
--- a/src/plugins/core/session/sessiondialog.cpp
+++ b/src/plugins/core/session/sessiondialog.cpp
@@ -79,6 +79,7 @@ void SessionDialog::initUI()
 void SessionDialog::initConnect()
 {
     connect(view, &SessionListView::sessionsSelected, this, &SessionDialog::updateOptions);
+    connect(view, &SessionListView::sessionSwitched, this, &SessionDialog::close);
     connect(addBtn, &DIconButton::clicked, view, &SessionListView::createSession);
     connect(renameBtn, &DIconButton::clicked, view, &SessionListView::renameCurrentSession);
     connect(cloneBtn, &DIconButton::clicked, view, &SessionListView::cloneCurrentSession);

--- a/src/plugins/core/session/sessionlistview.cpp
+++ b/src/plugins/core/session/sessionlistview.cpp
@@ -156,6 +156,7 @@ void SessionListView::switchToCurrentSession()
 {
     const auto session = currentSession();
     SessionManager::instance()->loadSession(session);
+    Q_EMIT sessionSwitched();
 }
 
 void SessionListView::showEvent(QShowEvent *event)

--- a/src/plugins/core/session/sessionlistview.h
+++ b/src/plugins/core/session/sessionlistview.h
@@ -30,6 +30,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void sessionsSelected(const QStringList &sessions);
     void sessionCreated(const QString &session);
+    void sessionSwitched();
 
 private:
     void initUI();


### PR DESCRIPTION
Enhance session management UX by automatically closing the session dialog
when user switches to a different session. This improvement streamlines
the workflow by:

- Adding new sessionSwitched signal in SessionListView
- Connecting dialog close action to session switch event
- Maintaining clean state transitions during session changes

Log: Add auto-close behavior to session dialog after session switch
Bug: https://pms.uniontech.com/bug-view-298077.html
