### PR TITLE
fix: [DirectoryAsynParse] Program crash

### DIFF
--- a/src/services/project/directoryasynparse.h
+++ b/src/services/project/directoryasynparse.h
@@ -27,14 +27,16 @@ public:
         bool isNormal = true;
     };
 
-    explicit DirectoryAsynParse(QStandardItem *root);
+    explicit DirectoryAsynParse();
     virtual ~DirectoryAsynParse();
 
     QSet<QString> getFilelist();
+    QStandardItem *findItem(const QString &path, QStandardItem *parent = nullptr) const;
+    void updateItem(QStandardItem *item);
 
 signals:
-    void itemsModified();
-    void itemUpdated(QStandardItem *item);
+    void itemsCreated(QList<QStandardItem *> itemList);
+    void reqUpdateItem(const QString &path);
     void parsedError(const ParseInfo<QString> &info);
 
 public slots:
@@ -45,11 +47,9 @@ private slots:
 
 private:
     void createRows(const QString &path);
-    QStandardItem *findItem(const QString &path, QStandardItem *parent = nullptr) const;
     QStandardItem *findParentItem(const QString &path, QStandardItem *parent = nullptr) const;
     QList<QStandardItem *> rows(const QStandardItem *item) const;
     QList<QStandardItem *> takeAll(QStandardItem *item);
-    void updateItem(QStandardItem *item);
 
     void sortItems();
     void sortChildren(QStandardItem *parentItem);

--- a/src/services/project/directorygenerator.h
+++ b/src/services/project/directorygenerator.h
@@ -29,8 +29,8 @@ public:
 protected:
     dpfservice::ProjectInfo prjInfo;
 public slots:
-    void doProjectChildsModified();
-    void handleItemUpdated(QStandardItem *item);
+    void projectItemsCreated(QList<QStandardItem *> itemList);
+    void handleItemUpdated(const QString &path);
 };
 
 }

--- a/src/services/project/projectgenerator.cpp
+++ b/src/services/project/projectgenerator.cpp
@@ -161,6 +161,7 @@ QStandardItem *dpfservice::ProjectGenerator::createRootItem(const dpfservice::Pr
     QString displyName = QFileInfo(info.workspaceFolder()).fileName();
     QString tooltip = info.workspaceFolder();
     auto rootItem = new QStandardItem(icon, displyName);
+    rootItem->setData(info.workspaceFolder(), Project::FilePathRole);
     rootItem->setToolTip(tooltip);
     return rootItem;
 }


### PR DESCRIPTION
QStandItem is not thread-safe, and operating on the QStandItem object in the thread causes the program to crash

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-298511.html
