### PR TITLE
fix: [debugger]  Error in displaying QList member variables

### DIFF
--- a/src/scripts/prettyprinters/qt.py
+++ b/src/scripts/prettyprinters/qt.py
@@ -118,7 +118,6 @@ class QListPrinter:
 
             self.externalStorage = isLarge or isStatic #see QList::Node::t()
 
-
         def __iter__(self):
             return self
 

--- a/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.h
+++ b/src/tools/debugadapter/debugger/gdbmi/gdbdebugger.h
@@ -122,7 +122,7 @@ private:
     void sendLibraryUnloadedNotify(const gdbmi::Library &library, bool print);
     void parseDisassembleData(const gdbmi::Record &record);
     void addVariablesWatched(const QList<gdbmi::Variable *> &variableList, int reference);
-    void parseChildVariable(const QString &evaluateName , const gdbmi::Variable *parentVariable);
+    void parseChildVariable(const QString &evaluateName , gdbmi::Variable *parentVariable);
     void evaluateValue(gdbmi::Variable *variable);
     void resetVariables();
     void checkVariablesLocker();

--- a/src/tools/debugadapter/debugger/gdbmi/gdbmi.cpp
+++ b/src/tools/debugadapter/debugger/gdbmi/gdbmi.cpp
@@ -191,7 +191,7 @@ gdbmi::Variable *gdbmi::Variable::parseMap(const QVariantMap &data)
     v->value = data.value("value").toString();
     v->type = data.value("type").toString();
     v->threadId = data.value("thread-id").toString();
-    v->hasMore = data.value("has_more", true).toBool();
+    v->hasMore = data.value("has_more", false).toBool();
     v->dynamic = data.value("dynamic", false).toBool();
     v->displayhint = data.value("displayhint").toString();
     return v;


### PR DESCRIPTION
When the variable is dynamic, it cannot be determined whether it has child members through attributes. Directly obtain it to observe whether it has child members’ is ‘When the variable is dynamic, it cannot be determined whether it has child members through properties. Directly access it to observe whether it has child members

Log: as title