### PR TITLE
fix: [search functionality] Resolve issue with empty editor content

### DIFF
--- a/src/plugins/find/maincontroller/worker/searchreplaceworker.cpp
+++ b/src/plugins/find/maincontroller/worker/searchreplaceworker.cpp
@@ -43,8 +43,8 @@ void SearchReplaceWorkerPrivate::startNextJob()
     process->setProgram(job.program);
     process->setArguments(job.arguments);
     process->start();
-    if (!job.channelData.isEmpty()) {
-        process->write(job.channelData.toUtf8());
+    if (job.channelData.has_value()) {
+        process->write(job.channelData->toUtf8());
         process->closeWriteChannel();
     }
 }

--- a/src/plugins/find/maincontroller/worker/searchreplaceworker_p.h
+++ b/src/plugins/find/maincontroller/worker/searchreplaceworker_p.h
@@ -17,7 +17,7 @@ public:
     {
         QString program;
         QStringList arguments;
-        QString channelData;
+        std::optional<QString> channelData;
         QString keyword;
         SearchFlags flags;
     };


### PR DESCRIPTION
This commit addresses a bug where the search functionality would not
work when the editor content was empty. The following changes were made:

- Changed the `channelData` type to `std::optional<QString>` to
  handle cases where there may not be any data to send.

These changes ensure that the search operation can gracefully handle
empty input, improving the overall robustness of the search feature.

Log: Fix search issue when editor content is empty
Bug: https://pms.uniontech.com/bug-view-298499.html
