### PR TITLE
fix: remove unused button

### DIFF
--- a/src/plugins/chat/widgets/askpagewidget.cpp
+++ b/src/plugins/chat/widgets/askpagewidget.cpp
@@ -196,11 +196,13 @@ void AskPageWidget::initInputWidget()
     historyBtn->hide(); // todo: Display after completion of functionality
     btnLayout->addWidget(historyBtn);
 
+#if 0 // history not ready
     createNewBtn = new DToolButton(this);
     createNewBtn->setIcon(QIcon::fromTheme("uc_chat_new"));
     createNewBtn->setFixedSize(26, 26);
     createNewBtn->setToolTip(tr("create new session"));
     btnLayout->addWidget(createNewBtn);
+#endif
     btnLayout->addStretch(1);
 
     modelCb = new QComboBox(this);
@@ -232,7 +234,7 @@ void AskPageWidget::initConnection()
     connect(inputEdit, &InputEditWidget::pressedEnter, this, &AskPageWidget::slotMessageSend);
     connect(deleteBtn, &DToolButton::clicked, this, &AskPageWidget::onDeleteBtnClicked);
     connect(historyBtn, &DToolButton::clicked, this, &AskPageWidget::onHistoryBtnClicked);
-    connect(createNewBtn, &DToolButton::clicked, this, &AskPageWidget::onCreateNewBtnClicked);
+//    connect(createNewBtn, &DToolButton::clicked, this, &AskPageWidget::onCreateNewBtnClicked);
     connect(modelCb, qOverload<int>(&QComboBox::currentIndexChanged), this, &AskPageWidget::onLLMChanged);
     connect(ChatCallProxy::instance(), &ChatCallProxy::LLMsChanged, this, &AskPageWidget::updateModelCb);
     connect(inputEdit->edit(), &DTextEdit::textChanged, this, [this]() {
@@ -288,8 +290,8 @@ void AskPageWidget::enterAnswerState()
         deleteBtn->setEnabled(false);
     if (historyBtn)
         historyBtn->setEnabled(false);
-    if (createNewBtn)
-        createNewBtn->setEnabled(false);
+//    if (createNewBtn)
+//        createNewBtn->setEnabled(false);
 
     stopWidget->show();
     waitForAnswer();
@@ -305,8 +307,8 @@ void AskPageWidget::enterInputState()
         deleteBtn->setEnabled(true);
     if (historyBtn)
         historyBtn->setEnabled(true);
-    if (createNewBtn)
-        createNewBtn->setEnabled(true);
+//    if (createNewBtn)
+//        createNewBtn->setEnabled(true);
 }
 
 void AskPageWidget::waitForAnswer()
@@ -373,7 +375,7 @@ void AskPageWidget::resetBtns()
         return;
 
     deleteBtn->setEnabled(!isIntroPageState());
-    createNewBtn->setVisible(!isIntroPageState());
+//    createNewBtn->setVisible(!isIntroPageState());
 //    historyBtn->setVisible(true);
 }
 


### PR DESCRIPTION
create session button in chat page not used

Log: https://pms.uniontech.com/bug-view-306951.html
Change-Id: If164025ff80b1153a85de084134504bb67050b23

## Summary by Sourcery

Chores:
- Removes unused create new session button.