### PR TITLE
fix: template dialog cannot stays on top in wayland

### DIFF
--- a/src/common/util/utils.h
+++ b/src/common/util/utils.h
@@ -8,6 +8,7 @@
 #include <DToolButton>
 
 #include <QAction>
+#include <QApplication>
 
 DWIDGET_USE_NAMESPACE
 namespace utils {
@@ -37,7 +38,11 @@ namespace utils {
 
         return iconBtn;
     }
-    
+
+    static bool isWayland()
+    {
+        return QApplication::platformName() == "wayland";
+    }
 }
 
 #endif

--- a/src/plugins/template/templatemanager.cpp
+++ b/src/plugins/template/templatemanager.cpp
@@ -8,6 +8,7 @@
 #include "services/window/windowservice.h"
 #include "base/abstractaction.h"
 #include "common/actionmanager/actionmanager.h"
+#include "common/util/utils.h"
 
 using namespace dpfservice;
 
@@ -69,5 +70,10 @@ void TemplateManager::addMenu()
 void TemplateManager::newWizard()
 {
     MainDialog *mainDlg = new MainDialog();
+
+    if (utils::isWayland()) {
+        mainDlg->setWindowFlag(Qt::WindowStaysOnTopHint, true);
+    }
+
     mainDlg->exec();
 }


### PR DESCRIPTION
set WindowStaysOnTopHint flag to resolve this issue

Log: bug fix
Bug: https://pms.uniontech.com/bug-view-306899.html
Change-Id: I21332f5f0e9d6f6afdb914fcb43170e7e8cfcb5d

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the template dialog does not stay on top in Wayland.