### PR TITLE
chore: rewrite model api placeholder

### DIFF
--- a/src/plugins/aimanager/option/modelconfigdialog.cpp
+++ b/src/plugins/aimanager/option/modelconfigdialog.cpp
@@ -65,7 +65,7 @@ void AddModelDialogPrivate::initUi()
     QLabel *lbApiUrl = new QLabel(ModelConfigDialog::tr("Api Path"));
     lbApiUrl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     leApiUrl = new DLineEdit(q);
-    leApiUrl->setPlaceholderText(ModelConfigDialog::tr("Required, please enter."));
+    leApiUrl->setPlaceholderText(ModelConfigDialog::tr("Root path, such as https://server/v1 (no /chat)"));
 
     QLabel *lbApiKey = new QLabel(ModelConfigDialog::tr("Api Key"));
     lbApiKey->setAlignment(Qt::AlignRight | Qt::AlignVCenter);


### PR DESCRIPTION
tell user not input api path with /chat

Log: bug fix
Bug: https://pms.uniontech.com/bug-view-306873.html
Change-Id: I81dbcd13d72cb9724c9c32d32e55272d15859804

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where users were incorrectly including '/chat' in the API path, as reported in https://pms.uniontech.com/bug-view-306873.html.