### PR TITLE
chore: optimize chat page Interaction

### DIFF
--- a/src/plugins/chat/widgets/askpagewidget.cpp
+++ b/src/plugins/chat/widgets/askpagewidget.cpp
@@ -284,7 +284,8 @@ void AskPageWidget::enterAnswerState()
 
     progressCalcNum = 0;
     inputEdit->edit()->clear();
-    inputEdit->setEnabled(false);
+    inputEdit->disableSendBtn();
+    inputEdit->setAnswering(true);
 
     if (deleteBtn)
         deleteBtn->setEnabled(false);
@@ -300,7 +301,8 @@ void AskPageWidget::enterAnswerState()
 void AskPageWidget::enterInputState()
 {
     stopWidget->hide();
-    inputEdit->setEnabled(true);
+    inputEdit->enableSendBtn();
+    inputEdit->setAnswering(false);
     inputEdit->edit()->setPlaceholderText(placeHolderText);
 
     if (deleteBtn)

--- a/src/plugins/chat/widgets/inputeditwidget.cpp
+++ b/src/plugins/chat/widgets/inputeditwidget.cpp
@@ -117,6 +117,8 @@ public:
     QStringList selectedFiles;
     QMap<QString, QStringList> tagMap;
 
+    bool isAnswering = false;
+
 private:
     void initEdit();
     void initButtonBox();
@@ -137,10 +139,13 @@ void InputEditWidgetPrivate::initEdit()
     edit->setAutoSelectCode(true);
     InputEditWidget::connect(edit, &InputEdit::textChanged, q, [this]() {
         auto currentText = edit->toPlainText();
-        if (currentText.isEmpty())
-            sendButton->setEnabled(false);
-        else
-            sendButton->setEnabled(true);
+
+        if (!isAnswering) {
+            if (currentText.isEmpty())
+                sendButton->setEnabled(false);
+            else
+                sendButton->setEnabled(true);
+        }
 
         q->setFixedHeight(edit->height() + buttonBox->height());
         auto cursor = edit->textCursor();
@@ -525,7 +530,7 @@ bool InputEditWidget::eventFilter(QObject *watched, QEvent *event)
             case Qt::Key_Return:
                 if (keyEvent->modifiers() & Qt::AltModifier)
                     d->edit->insertPlainText("\n");
-                else if (!d->referencePopup->isVisible())
+                else if (!d->referencePopup->isVisible() && !d->isAnswering)
                     emit pressedEnter();
                 else
                     emit handleKey(keyEvent);
@@ -631,6 +636,21 @@ void InputEditWidget::switchNetworkBtnVisible(bool visible)
         d->netWorkBtn->setChecked(false);
         ChatManager::instance()->connectToNetWork(false);
     }
+}
+
+void InputEditWidget::enableSendBtn()
+{
+    d->sendButton->setEnabled(true);
+}
+
+void InputEditWidget::disableSendBtn()
+{
+    d->sendButton->setEnabled(false);
+}
+
+void InputEditWidget::setAnswering(bool isAnswering)
+{
+    d->isAnswering = isAnswering;
 }
 
 // use to restore tag, : remove tag then Ctrl+z

--- a/src/plugins/chat/widgets/inputeditwidget.h
+++ b/src/plugins/chat/widgets/inputeditwidget.h
@@ -69,6 +69,10 @@ public:
     void popupReference();
     void accept(const QModelIndex &index);
     void switchNetworkBtnVisible(bool visible);
+    void enableSendBtn();
+    void disableSendBtn();
+
+    void setAnswering(bool isAnswering);
 
 signals:
     void pressedEnter();


### PR DESCRIPTION
user can input when chat is answering

Log: optimize
Bug: https://pms.uniontech.com/bug-view-306865.html
Change-Id: I81eb2a612d2dccf90f9cba78120895f921889285

## Summary by Sourcery

Allows the user to input text while the chat is answering by disabling the send button and preventing the submission of messages via the enter key. Re-enables the send button when the chat is no longer answering.