### PR TITLE
fix: models translation missed

### DIFF
--- a/src/plugins/aimanager/option/optioncustommodelsgenerator.h
+++ b/src/plugins/aimanager/option/optioncustommodelsgenerator.h
@@ -9,6 +9,7 @@
 
 class OptionCustomModelsGenerator : public dpfservice::OptionGenerator
 {
+    Q_OBJECT
 public:
     OptionCustomModelsGenerator();
     inline static QString kitName() { return tr("Models"); }


### PR DESCRIPTION
add q_object in class to void this issue

Log: bug fix
Change-Id: Ia367d56b01d95f8bf4e0ac784abc27c9fc1ddad6

## Summary by Sourcery

Bug Fixes:
- Add Q_OBJECT macro to OptionCustomModelsGenerator class to fix translation issues.