### PR TITLE
fix: wrong initialize position

### DIFF
--- a/src/plugins/aimanager/aiplugin.cpp
+++ b/src/plugins/aimanager/aiplugin.cpp
@@ -16,12 +16,21 @@
 
 void AiPlugin::initialize()
 {
+    // load Ai service.
+    QString errStr;
+    auto &ctx = dpfInstance.serviceContext();
+    if (!ctx.load(dpfservice::AiService::name(), &errStr)) {
+        qCritical() << errStr;
+    }
 }
 
 bool AiPlugin::start()
 {    
     using namespace dpfservice;
     auto aiService = dpfGetService(AiService);
+    if (!aiService)
+        return false;
+
     auto impl = AiManager::instance();
     using namespace std::placeholders;
     aiService->getAllModel = std::bind(&AiManager::getAllModel, impl);

--- a/src/plugins/chat/chat.cpp
+++ b/src/plugins/chat/chat.cpp
@@ -12,7 +12,6 @@
 #include "services/window/windowservice.h"
 #include "services/option/optionservice.h"
 #include "services/option/optiondatastruct.h"
-#include "services/ai/aiservice.h"
 #include "services/editor/editorservice.h"
 #include "copilot.h"
 
@@ -27,12 +26,6 @@ using namespace dpfservice;
 
 void ChatPlugin::initialize()
 {
-    // load Ai service.
-    QString errStr;
-    auto &ctx = dpfInstance.serviceContext();
-    if (!ctx.load(AiService::name(), &errStr)) {
-        qCritical() << errStr;
-    }
 }
 
 bool ChatPlugin::start()


### PR DESCRIPTION
Log:
Change-Id: Iec6ec233f3564020fe825600d8947390cfe5855e

## Summary by Sourcery

Move AI service initialization from plugin initialize methods to their start methods to ensure proper service loading

Bug Fixes:
- Correct the initialization position of AI service loading to prevent potential initialization errors

Enhancements:
- Refactor AI service loading logic to be more robust by moving service initialization to the start method