### PR TITLE
fix: crash when use inlinechat

### DIFF
--- a/src/plugins/chat/widgets/inlinechatwidget.cpp
+++ b/src/plugins/chat/widgets/inlinechatwidget.cpp
@@ -555,8 +555,7 @@ bool InlineChatWidgetPrivate::askForChat()
     answerLabel->clear();
 
     auto *futureWatcher = new QFutureWatcher<QString>();
-    // futureWatcher->setFuture(QtConcurrent::run(this, &InlineChatWidgetPrivate::createPrompt, question, false));
-    futureWatcher->setFuture(QtConcurrent::run([this, &question](){ return this->createPrompt(question, false); }));
+    futureWatcher->setFuture(QtConcurrent::run([this, question](){ return this->createPrompt(question, false); }));
     connect(futureWatcher, &QFutureWatcher<QString>::finished, this, &InlineChatWidgetPrivate::handleCreatePromptFinished);
     futureWatcherList << futureWatcher;
     return true;


### PR DESCRIPTION
Log:
Bug: https://pms.uniontech.com/bug-view-314743.html Change-Id: I9ccdb5b6ad4bf6e51d805e6b71aef77098fdd540

## Summary by Sourcery

Bug Fixes:
- Resolved a potential crash in the inline chat widget by fixing the lambda capture mechanism when creating a prompt