### PR TITLE
fix: crashed when open plugin detail page

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -4,6 +4,7 @@
 
 #include "common/common.h"
 #include "common/settings/settings.h"
+#include "common/util/utils.h"
 
 #include <framework/framework.h>
 #include <framework/lifecycle/pluginsetting.h>
@@ -103,10 +104,12 @@ void openProject(const QString &path)
 int main(int argc, char *argv[])
 {
     // some platform opengl drive with wrong，so use OpenGLES instead.
-    if (QSysInfo::currentCpuArchitecture().contains("arm")) {
-        QSurfaceFormat format;
-        format.setRenderableType(QSurfaceFormat::OpenGLES);
-        format.setDefaultFormat(format);
+    if(utils::isWayland())  {
+        if (QSysInfo::currentCpuArchitecture().contains("arm")) {
+            QSurfaceFormat format;
+            format.setRenderableType(QSurfaceFormat::OpenGLES);
+            format.setDefaultFormat(format);
+        }
     }
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
Log:
Bug: https://pms.uniontech.com/bug-view-314807.html Change-Id: Ica69be9473023d282fb3e3ed5b09e2188d61d65e

## Summary by Sourcery

Bug Fixes:
- Fix a crash when opening the plugin detail page on certain ARM/Wayland environments.