### PR TITLE
fix: block when debug python code

### DIFF
--- a/src/plugins/debugger/dap/debugsession.cpp
+++ b/src/plugins/debugger/dap/debugsession.cpp
@@ -785,7 +785,6 @@ void DebugSession::setName(string &_name)
 void DebugSession::shutdown()
 {
     if (raw) {
-        raw->disconnect({});
         raw.reset(nullptr);
     }
 }


### PR DESCRIPTION
disconnect to debugpy that has closed

Log:
Change-Id: Ia57b8165dd7d2547c5053aee1776be22d2ac8f9b

## Summary by Sourcery

Bug Fixes:
- Removed unnecessary disconnection call that may cause problems when closing a debug session