### PR TITLE
fix: Adapting to QProcess Usage in Qt 6

### DIFF
--- a/src/tools/debugadapter/debugger/python/pythondebugger.cpp
+++ b/src/tools/debugadapter/debugger/python/pythondebugger.cpp
@@ -115,7 +115,7 @@ void PythonDebugger::initialize(const QString &pythonExecute,
     auto checkPortFree = [](int port) {
         QProcess process;
         QString cmd = QString("fuser %1/tcp").arg(port);
-        process.start(cmd);
+        process.start("bash", {"-c", cmd});
         process.waitForFinished();
         QString ret = process.readAll();
         if (ret.isEmpty())


### PR DESCRIPTION
Log: The abnormal execution of QProcess resulted in empty fuser output, causing port availability verification to fail, which ultimately led to connection failures with the correct debugging backend and freeze ide

Bug: https://pms.uniontech.com/bug-view-315851.html

## Summary by Sourcery

Bug Fixes:
- Invoke fuser via `bash -c` instead of directly passing the command to QProcess to capture its output correctly.