### PR TITLE
fix: can`t handle terminated event from debugpy

### DIFF
--- a/3rdparty/cppdap/src/session.cpp
+++ b/3rdparty/cppdap/src/session.cpp
@@ -30,6 +30,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <set>
 
 #ifdef ENABLE_LOG
 #define Log(message) printf("%s", message);
@@ -418,7 +419,9 @@ class Impl : public dap::Session {
     // "body" is an optional field for some events, such as "Terminated Event".
     bool body_ok = true;
     d->field("body", [&](dap::Deserializer* d) {
-        if (!typeinfo->deserialize(d, data)) {
+        // todo: to completed
+        std::set<std::string> bodyCanBeEmpty { "terminated" };
+        if (!typeinfo->deserialize(d, data) && bodyCanBeEmpty.find(event) == bodyCanBeEmpty.end()) {
             body_ok = false;
         }
         return true;

--- a/src/common/widget/appoutputpane.cpp
+++ b/src/common/widget/appoutputpane.cpp
@@ -267,6 +267,15 @@ void AppOutputPane::createApplicationPane(const QString &id, const QString &prog
     emit paneCreated(id);
 }
 
+void AppOutputPane::setProcessStarted(const QString &id)
+{
+    if (!d->appIsRunning.contains(id))
+        return;
+    d->appIsRunning[id] = true;
+    if (d->stackWidget->currentWidget() == d->appPane[id])
+        d->closeProcessBtn->setEnabled(true);
+}
+
 void AppOutputPane::setProcessFinished(const QString &id)
 {
     if (!d->appIsRunning.contains(id))

--- a/src/common/widget/appoutputpane.h
+++ b/src/common/widget/appoutputpane.h
@@ -32,6 +32,7 @@ public:
                                  OutputPane::OutputFormat format,
                                  OutputPane::AppendMode mode);
 
+    void setProcessStarted(const QString &id);
     void setProcessFinished(const QString &id);
 
     using StopHandler = std::function<void()>;

--- a/src/plugins/debugger/dap/dapdebugger.cpp
+++ b/src/plugins/debugger/dap/dapdebugger.cpp
@@ -89,7 +89,6 @@ class DebuggerPrivate
     DEBUG::DebugSession *currentSession { nullptr };
 
     dap::integer threadId = 0;
-    QList<dap::integer> threads;
     StackFrameData currentValidFrame;
 
     /**
@@ -736,17 +735,6 @@ void DAPDebugger::registerDapHandlers()
         Q_UNUSED(event)
         qInfo() << "\n--> recv : "
                 << "ThreadEvent";
-
-        if (event.reason == "started")
-            d->threads.append(event.threadId);
-
-        if (event.reason == "exited") {
-            d->threads.removeOne(event.threadId);
-            if (d->threads.isEmpty()) {
-                printOutput(tr("\nThe debugee has Terminated.\n"), OutputPane::OutputFormat::NormalMessage);
-                updateRunState(kNoRun);
-            }
-        }
     });
 
     // The event indicates that the target has produced some output.
@@ -1361,7 +1349,6 @@ void DAPDebugger::exitDebug()
 
     d->threadId = 0;
 
-    d->threads.clear();
     d->threadSelector->clear();
 }
 

--- a/src/plugins/debugger/dap/dapdebugger.cpp
+++ b/src/plugins/debugger/dap/dapdebugger.cpp
@@ -213,6 +213,19 @@ void DAPDebugger::startDebug()
     if (d->currentSession == d->remoteSession)
         d->currentSession = d->localSession;
 
+    QMetaObject::invokeMethod(this, [=](){
+        auto appOutPutPane = AppOutputPane::instance();
+        appOutPutPane->createApplicationPane("debugPane", "debugTarget");
+        appOutPutPane->setStopHandler("debugPane", [=]() {
+            abortDebug();
+            d->outputPane = appOutPutPane->defaultPane();
+        });
+        d->outputPane = appOutPutPane->getOutputPaneById("debugPane");
+
+        appOutPutPane->bindToolBarToPane(debugToolBarName, d->outputPane);
+        AppOutputPane::instance()->setProcessFinished("debugPane"); // only show log untill debuggee launching
+    });
+
     auto &ctx = dpfInstance.serviceContext();
     LanguageService *service = ctx.service<LanguageService>(LanguageService::name());
     if (service) {
@@ -1600,16 +1613,7 @@ void DAPDebugger::launchSession(int port, const QMap<QString, QVariant> &param, 
     } else {
         debugService->getModel()->clear();
         debugService->getModel()->addSession(d->currentSession);
-
-        auto appOutPutPane = AppOutputPane::instance();
-        appOutPutPane->createApplicationPane("debugPane", "debugTarget");
-        appOutPutPane->setStopHandler("debugPane", [=]() {
-            abortDebug();
-            d->outputPane = appOutPutPane->defaultPane();
-        });
-        d->outputPane = appOutPutPane->getOutputPaneById("debugPane");
-
-        appOutPutPane->bindToolBarToPane(debugToolBarName, d->outputPane);
+        AppOutputPane::instance()->setProcessStarted("debugPane");
     }
 }
 

--- a/src/plugins/debugger/dap/dapdebugger.h
+++ b/src/plugins/debugger/dap/dapdebugger.h
@@ -132,7 +132,7 @@ private:
     void launchSession(int port, const QMap<QString, QVariant> &param, const QString &kitName);
     void disassemble(const QString &address);
     void handleAssemble(const QString &content);
-    
+
     QString transformRemotePath(const QString &remotePath);
     
     dpfservice::ProjectInfo getActiveProjectInfo() const;


### PR DESCRIPTION
Log: cppdap does not process event which body is empty, but 'body'is an optional filed, it should handle such cases.

Bug:

## Summary by Sourcery

Allow processing of DAP events with empty bodies and remove obsolete thread-based termination logic.

Bug Fixes:
- Whitelist the "terminated" event so cppdap handles it even when its body is empty.
- Remove thread tracking in DAPDebugger that blocked termination detection for events with empty bodies.

Enhancements:
- Add <set> include to support event whitelist.