### PR TITLE
fix: add pip existence check before installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ doc/html/*
 # union code gen
 .unioncode
 *.unioncode
+.cursorindexingignore
+.specstory

--- a/src/plugins/python/installer/pipinstaller.h
+++ b/src/plugins/python/installer/pipinstaller.h
@@ -25,6 +25,7 @@ public:
     void install(const QString &python, const InstallInfo &info);
 
 private:
+    bool checkPipExists(const QString &python);
     dpfservice::TerminalService *termSrv { nullptr };
 };
 


### PR DESCRIPTION
- Implemented a method to check if pip is installed before attempting to install packages. If pip is not found, the installer will now install python3-pip first and then proceed with the package installation.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-316965.html